### PR TITLE
Use vanilla CentOS 7 box in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "boxcutter/centos7-desktop"
+  config.vm.box = "centos/7"
 
   config.ssh.forward_agent = true
   config.vm.network "forwarded_port", guest: 8080, host: 8080


### PR DESCRIPTION
@geirst please review

Caveat: now requires vagrant-vbguest plugin installed for mounting
to work as expected when doing vagrant up.