### PR TITLE
Update dependency versions in the 'validate' phase.

### DIFF
--- a/basic-search-java/pom.xml
+++ b/basic-search-java/pom.xml
@@ -88,7 +88,7 @@
                 <configuration>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <generateBackupPoms>false</generateBackupPoms>
-                    <includeProperties>junit_version, vespa_version</includeProperties>
+                    <includeProperties>vespa_version</includeProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/basic-search-java/pom.xml
+++ b/basic-search-java/pom.xml
@@ -90,6 +90,14 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>junit_version, vespa_version</includeProperties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/basic-search-tensor/pom.xml
+++ b/basic-search-tensor/pom.xml
@@ -88,7 +88,7 @@
                 <configuration>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <generateBackupPoms>false</generateBackupPoms>
-                    <includeProperties>junit_version, vespa_version</includeProperties>
+                    <includeProperties>vespa_version</includeProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/basic-search-tensor/pom.xml
+++ b/basic-search-tensor/pom.xml
@@ -90,6 +90,14 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>junit_version, vespa_version</includeProperties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/blog-recommendation/pom.xml
+++ b/blog-recommendation/pom.xml
@@ -91,6 +91,14 @@
           <generateBackupPoms>false</generateBackupPoms>
           <includeProperties>junit_version, vespa_version</includeProperties>
         </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>update-properties</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <!-- For debugging only -->

--- a/blog-recommendation/pom.xml
+++ b/blog-recommendation/pom.xml
@@ -89,7 +89,7 @@
         <configuration>
           <allowMajorUpdates>false</allowMajorUpdates>
           <generateBackupPoms>false</generateBackupPoms>
-          <includeProperties>junit_version, vespa_version</includeProperties>
+          <includeProperties>vespa_version</includeProperties>
         </configuration>
         <executions>
           <execution>

--- a/boolean-search/pom.xml
+++ b/boolean-search/pom.xml
@@ -85,7 +85,7 @@
                 <configuration>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <generateBackupPoms>false</generateBackupPoms>
-                    <includeProperties>junit_version, vespa_version</includeProperties>
+                    <includeProperties>vespa_version</includeProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/boolean-search/pom.xml
+++ b/boolean-search/pom.xml
@@ -87,6 +87,14 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>junit_version, vespa_version</includeProperties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/http-api-using-request-handlers-and-processors/pom.xml
+++ b/http-api-using-request-handlers-and-processors/pom.xml
@@ -88,7 +88,7 @@
                 <configuration>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <generateBackupPoms>false</generateBackupPoms>
-                    <includeProperties>junit_version, vespa_version</includeProperties>
+                    <includeProperties>vespa_version</includeProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/http-api-using-request-handlers-and-processors/pom.xml
+++ b/http-api-using-request-handlers-and-processors/pom.xml
@@ -90,6 +90,14 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>junit_version, vespa_version</includeProperties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/http-api-using-searcher/pom.xml
+++ b/http-api-using-searcher/pom.xml
@@ -88,7 +88,7 @@
                 <configuration>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <generateBackupPoms>false</generateBackupPoms>
-                    <includeProperties>junit_version, vespa_version</includeProperties>
+                    <includeProperties>vespa_version</includeProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/http-api-using-searcher/pom.xml
+++ b/http-api-using-searcher/pom.xml
@@ -90,6 +90,14 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>junit_version, vespa_version</includeProperties>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>update-properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->


### PR DESCRIPTION
Let the pom update itself upon building. This means that the user will from time to time have one build with outdated vespa_version, but the next build will use the latest release. 

NOTE: the user will get unstaged changes preventing git pull after the version has auto-updated. But the alternative is a gradually more outdated version until the user runs git pull manually.

FYI: @frodelu, @bratseth 
