### PR TITLE
Revert "Update dependency versions in the 'validate' phase."

### DIFF
--- a/basic-search-java/pom.xml
+++ b/basic-search-java/pom.xml
@@ -90,14 +90,6 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>vespa_version</includeProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>update-properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/basic-search-tensor/pom.xml
+++ b/basic-search-tensor/pom.xml
@@ -90,14 +90,6 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>vespa_version</includeProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>update-properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/blog-recommendation/pom.xml
+++ b/blog-recommendation/pom.xml
@@ -91,14 +91,6 @@
           <generateBackupPoms>false</generateBackupPoms>
           <includeProperties>vespa_version</includeProperties>
         </configuration>
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>update-properties</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <!-- For debugging only -->

--- a/boolean-search/pom.xml
+++ b/boolean-search/pom.xml
@@ -87,14 +87,6 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>vespa_version</includeProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>update-properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/http-api-using-request-handlers-and-processors/pom.xml
+++ b/http-api-using-request-handlers-and-processors/pom.xml
@@ -90,14 +90,6 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>vespa_version</includeProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>update-properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->

--- a/http-api-using-searcher/pom.xml
+++ b/http-api-using-searcher/pom.xml
@@ -90,14 +90,6 @@
                     <generateBackupPoms>false</generateBackupPoms>
                     <includeProperties>vespa_version</includeProperties>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>update-properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <!-- For debugging only -->


### PR DESCRIPTION
Reverts parts of #33, which was sent a bit late on a Friday afternoon

An application should never be built on a newer vespa version than it will be running on. Always upgrade vespa on the runtime system before upgrading the vespa deps on the build system.

You can always run the version update manually with `mvn versions:update-properties`