### PR TITLE
Fix blog recommentation doc test

### DIFF
--- a/blog-recommendation/README.md
+++ b/blog-recommendation/README.md
@@ -31,7 +31,7 @@ $ curl -s --head http://localhost:8080/ApplicationStatus
 </pre>
 **Test the application:**
 <pre data-test="exec" data-test-assert-contains='"coverage":100,"documents":0'>
-$ curl 'http://localhost:8080/search/?user_id=0&searchChain=user&query=sddocname:blog_post'
+$ curl 'http://localhost:8080/search/?user_id=0&amp;searchChain=user&amp;query=sddocname:blog_post'
 </pre>
 **Shutdown and remove the container:**
 <pre data-test="after">


### PR DESCRIPTION
Fixed documentation test because HTML parser expect `&` to be an escape character.