### PR TITLE
Set corret bundle name

### DIFF
--- a/generic-request-processing/src/main/application/services.xml
+++ b/generic-request-processing/src/main/application/services.xml
@@ -5,7 +5,7 @@
     <container id="default" version="1.0">
         <processing>
             <chain id="default">
-                <processor id="com.mydomain.example.ExampleProcessor" bundle="basic-request-processing">
+                <processor id="com.mydomain.example.ExampleProcessor" bundle="generic-request-processing">
                     <config name="com.mydomain.example.example-processor">
                         <message>Hello, services!</message>
                     </config>


### PR DESCRIPTION
The test in README.md failed because the application would not deploy due to incorrect bundle name.