### PR TITLE
Set default query profile type

### DIFF
--- a/basic-search-tensor/src/main/application/search/query-profiles/default.xml
+++ b/basic-search-tensor/src/main/application/search/query-profiles/default.xml
@@ -1,0 +1,2 @@
+<query-profile id="default" type="root">
+</query-profile>


### PR DESCRIPTION
@lesters please review

Not strictly needed here because you set the tensor programmatically so the type is derived from the value, but makes things easier to build on.