### PR TITLE
Add model-evaluation to aggregator pom.

### DIFF
--- a/model-evaluation/pom.xml
+++ b/model-evaluation/pom.xml
@@ -6,7 +6,7 @@
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>ai.vespa.example</groupId>
-    <artifactId>my-model-evaluation</artifactId>
+    <artifactId>model-evaluation</artifactId>
     <version>1.0.1</version>
     <packaging>container-plugin</packaging>  <!-- Use Vespa packaging -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,5 +17,6 @@
         <module>generic-request-processing</module>
         <module>http-api-using-request-handlers-and-processors</module>
         <module>http-api-using-searcher</module>
+        <module>model-evaluation</module>
     </modules>
 </project>


### PR DESCRIPTION
This is necessary to get the vespa version property updated by the opensource-release-trigger job. (The 'my-' part of the artifactId is removed just because it stands out from the rest of the samples.)