### PR TITLE
Add annotation due to modification of YQL query tree

### DIFF
--- a/blog-recommendation/src/main/java/com/yahoo/example/UserProfileSearcher.java
+++ b/blog-recommendation/src/main/java/com/yahoo/example/UserProfileSearcher.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.example;
 
+import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.data.access.Inspectable;
 import com.yahoo.data.access.Inspector;
 import com.yahoo.prelude.query.AndItem;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+@After("ExternalYql")
 public class UserProfileSearcher extends Searcher {
 
     public Result search(Query query, Execution execution) {


### PR DESCRIPTION
Searchers which modify the query tree constructed from input YQL statements need to be annotated to work as expected (see: https://docs.vespa.ai/documentation/reference/query-language-reference.html).

Just let me know if there's anything else I need to address here.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
