### PR TITLE
Add explicit id for container clusters

### DIFF
--- a/basic-search-on-docker-swarm/src/main/application/services.xml
+++ b/basic-search-on-docker-swarm/src/main/application/services.xml
@@ -11,7 +11,7 @@
     </configservers>
   </admin>
 
-  <container version="1.0">
+  <container id="container" version="1.0">
     <document-api />
     <document-processing/>
     <search />

--- a/basic-search-tensor/src/main/application/services.xml
+++ b/basic-search-tensor/src/main/application/services.xml
@@ -7,7 +7,7 @@
         <adminserver hostalias="node1"/>
     </admin>
 
-    <container version="1.0">
+    <container id="container" version="1.0">
         <search>
             <chain id="default" inherits="vespa">
                 <searcher id="com.yahoo.example.ExampleTensorSearcher" bundle="basic-search-tensor" />


### PR DESCRIPTION
* Best practice to avoid implicit id that depends on xml tag name.

