### PR TITLE
Remove notifications from deployment.xml

### DIFF
--- a/album-recommendation-java/src/main/application/deployment.xml
+++ b/album-recommendation-java/src/main/application/deployment.xml
@@ -1,9 +1,5 @@
 <!-- Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <deployment version="1.0">
-  <notifications>
-    <email address="user@domain.com" when="failing" />
-    <email role="author" />
-  </notifications>
   <prod>
     <!-- region active="true">aws-us-east-1c</region -->
   </prod>


### PR DESCRIPTION
`<notifications>` element is not supported on Vespa Cloud, so removing it from sample-app we use for Cloud until it is supported.
