### PR TITLE
will migrate to using namespace

### DIFF
--- a/vespa-cloud/vespa-documentation-search/src/main/application/searchdefinitions/doc.sd
+++ b/vespa-cloud/vespa-documentation-search/src/main/application/searchdefinitions/doc.sd
@@ -24,6 +24,11 @@ search doc {
             indexing: summary | attribute
         }
 
+        # e.g. open, cloud
+        field namespace type string {
+            indexing: summary | attribute
+        }
+        
     }
 
     fieldset default {


### PR DESCRIPTION
- as documents will be separated in the index by the namespace feature in the ID - this is hence a better name