### PR TITLE
More small fixes

### DIFF
--- a/vespa-cloud/cord-19-search/blacklist.txt
+++ b/vespa-cloud/cord-19-search/blacklist.txt
@@ -313,3 +313,11 @@ from the library
 carlo urbani
 new products
 medicine and books
+influenza
+influenza a
+sars
+mers
+merscov
+pandemic influenza
+pandemic
+dengue virus

--- a/vespa-cloud/cord-19-search/scripts/add-citation-data.py
+++ b/vespa-cloud/cord-19-search/scripts/add-citation-data.py
@@ -11,7 +11,6 @@ def get(df_row, key, defaultValue):
     return defaultValue
   else:
     return value
-  
 
 def to_tally(row):
   return {

--- a/vespa-cloud/cord-19-search/scripts/compute-inbound-citations.py
+++ b/vespa-cloud/cord-19-search/scripts/compute-inbound-citations.py
@@ -5,28 +5,46 @@ import json
 DATA_FILE = sys.argv[1]
 
 def nor(s):
-  if not s: s = "nope"
-  return re.sub(r'[0-9!"#$%&()*+,-./:;<=>?@[\]^_`{|}~]+', "", s).lower()
+  return re.sub(r' +', " ", re.sub(r'[0-9!"#$%&()*+,./:;<=>?@[\]^_`{|}~\'—–-]+', "", s or "")).lower().strip()
 
 duplicates = 0
 docs = {}
 with open(DATA_FILE, 'r') as f:
   for doc in json.load(f):
-    if nor(doc['title']) in docs.keys():
+    title = nor(doc['title'])
+    if title in docs.keys():
       #print("Duplicate title %s" % doc['title'], file=sys.stderr)
+      docs[title].append(doc)
       duplicates = duplicates + 1
-    docs[nor(doc['title'])] = doc
+    else:
+      docs[title] = [doc]
     doc['cited_by'] = []
 print("Total duplicates %d" % duplicates, file=sys.stderr)
 
 inbound = 0
-for title in docs.keys():
-  doc = docs[title]
-  for ref in doc['bib_entries']:
-    if nor(ref['title']) in docs.keys():
-      docs[nor(ref['title'])]['cited_by'].append(doc['id'])
-      inbound = inbound + 1
+for ds in docs.values():
+  for doc in ds:
+    for ref in doc['bib_entries']:
+      title = nor(ref['title'])
+      if title in docs.keys():
+        for cited in docs[title]:
+          cited['cited_by'].append(doc['id'])
+        inbound = inbound + 1
+      else:
+        matches = []
+        for key in docs.keys():
+          if title.startswith(key):
+            matches.append(key)
+        matches.sort(key=lambda m: len(m), reverse=True)
+        if len(matches) > 0:
+          for cited in docs[matches[0]]:
+            cited['cited_by'].append(doc['id'])
+          inbound = inbound + 1
+
 print("Total inbound hits %d" % inbound, file=sys.stderr)
 
-print(json.dumps(list(docs.values())))
+to_print = []
+for ds in docs.values(): to_print.extend(ds)
+
+print(json.dumps(to_print))
 


### PR DESCRIPTION
@jobergum please review and merge. Still hacking away at the citation extraction. Seems the scite dataset does case-sensitive DOI matching, while the doi.org ignores case, and so they miss some references. 
The bib_entries also have journal appended to title for quite a few refs, so this lets the longest title which is a prefix of a bib_entry item  count as a match