### PR TITLE
Implement related_to:id

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
@@ -1,4 +1,6 @@
 <!-- Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <query-profile-type id="root" inherits="native">
-  <field name="ranking.features.query(vector)" type="tensor&lt;float&gt;(x[768])" />
+  field name="ranking.features.query(vector)" type="tensor&lt;float&gt;(x[768])" />
+  <field name="ranking.features.query(title_vector)" type="tensor&lt;float&gt;(x[768])" />
+  <field name="ranking.features.query(abstract_vector)" type="tensor&lt;float&gt;(x[768])" />
 </query-profile-type>

--- a/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
@@ -1,6 +1,6 @@
 <!-- Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <query-profile-type id="root" inherits="native">
-  field name="ranking.features.query(vector)" type="tensor&lt;float&gt;(x[768])" />
+  <field name="ranking.features.query(vector)" type="tensor&lt;float&gt;(x[768])" />
   <field name="ranking.features.query(title_vector)" type="tensor&lt;float&gt;(x[768])" />
   <field name="ranking.features.query(abstract_vector)" type="tensor&lt;float&gt;(x[768])" />
 </query-profile-type>

--- a/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
+++ b/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
@@ -1,5 +1,6 @@
 #Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. 
 search doc {
+
   document doc { 
 
     struct author {
@@ -202,7 +203,7 @@ search doc {
     field title_embedding type tensor<float>(x[768]) {
       indexing: attribute
     }
-
+    field related_to type int {}
   }
 
   fieldset default {
@@ -292,6 +293,23 @@ search doc {
         expression: 0.7*rawScore(title_embedding) + 0.3*rawScore(abstract_embedding)
       }
   }
+
+  rank-profile related-ann-with-matching inherits default {
+        function match_score() {
+          expression: nativeRank(title) + nativeRank(abstract)
+        }
+        function vector_score(){
+          expression: rawScore(title_embedding) + rawScore(abstract_embedding)
+        }
+        first-phase {
+          expression: 0.8*vector_score() + 0.2*match_score()
+        }
+        summary-features {
+          vector_score()
+          match_score()
+        }
+
+    }
 
   rank-profile semantic-search-abstract {
     first-phase {

--- a/vespa-cloud/cord-19-search/src/main/application/services.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/services.xml
@@ -8,7 +8,11 @@
           <chain id="related" inherits="vespa">
             <searcher id="ai.vespa.example.cord19.searcher.RelatedPaperSearcher" bundle="cord-19"/>
           </chain>
+          <!--Keep existing chain until frontend switches -->
           <chain id="related-ann" inherits="vespa">
+            <searcher id="ai.vespa.example.cord19.searcher.RelatedPaperSearcherANN" bundle="cord-19"/>
+          </chain>
+          <chain id="default" inherits="vespa">
             <searcher id="ai.vespa.example.cord19.searcher.RelatedPaperSearcherANN" bundle="cord-19"/>
           </chain>
 

--- a/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/RelatedPaperSearcherANN.java
+++ b/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/RelatedPaperSearcherANN.java
@@ -26,7 +26,7 @@ import com.yahoo.tensor.Tensor;
 
 public class RelatedPaperSearcherANN extends Searcher {
 
-    public static String RELATED_RANKING_PROFILE = "related-ann-with-matching";
+
     public static String RELATED_TO_FIELD = "related_to";
 
     public static CompoundName INPUT_ID = new CompoundName("id");
@@ -75,7 +75,6 @@ public class RelatedPaperSearcherANN extends Searcher {
             notItem.addNegativeItem(new WordItem(id.toString(), "id", true));
             relatedQuery.getModel().getQueryTree().setRoot(notItem);
         }
-        relatedQuery.getRanking().setProfile(RELATED_RANKING_PROFILE);
         return execution.search(relatedQuery);
     }
 


### PR DESCRIPTION
Examples

/search/?query=%2Brelated_to:612 %2Bschools

Will do approximate nearest neighboor search using title embedding vector from article 612 and include 'schools's as a matching term. Ranking is done by related-ann-with-matching which is a combination of rawScore(embedding vector) and Vespa's nativeRank. 


Searcher triggers on &id=x, or presence of related_to IntItem in the query (Which is removed before hitting the backend) 
