### PR TITLE
Sort dates in the future correctly

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
+++ b/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
@@ -290,7 +290,7 @@ search doc {
   
   rank-profile freshness inherits default {
     first-phase {
-      expression: freshness(timestamp)
+      expression: attribute(timestamp)
     }
   }
 


### PR DESCRIPTION
Freshness will use "now" as the highest time by default, so
articles dated in the future will all sort the same.
