### PR TITLE
Add new embedding released with 2020-04-10 dataset

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/types/root.xml
@@ -3,4 +3,5 @@
   <field name="ranking.features.query(vector)" type="tensor&lt;float&gt;(x[768])" />
   <field name="ranking.features.query(title_vector)" type="tensor&lt;float&gt;(x[768])" />
   <field name="ranking.features.query(abstract_vector)" type="tensor&lt;float&gt;(x[768])" />
+  <field name="ranking.features.query(specter_vector)" type="tensor&lt;float&gt;(x[768])" />
 </query-profile-type>

--- a/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
+++ b/vespa-cloud/cord-19-search/src/main/application/searchdefinitions/doc.sd
@@ -219,6 +219,11 @@ search doc {
     field title_embedding type tensor<float>(x[768]) {
       indexing: attribute
     }
+
+    field specter_embedding type tensor<float>(x[768]) {
+      indexing: attribute
+    }
+
     field related_to type int {}
   }
 


### PR DESCRIPTION
With the 2020-04-10 cord-19 dataset we also got something they call SPECTER paper embeddings, 768 dimensional embedding. https://github.com/allenai/paper-embedding-public-apis

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
