### PR TITLE
Jobergum/bolding control

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/services.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/services.xml
@@ -14,6 +14,7 @@
           </chain>
           <chain id="default" inherits="vespa">
             <searcher id="ai.vespa.example.cord19.searcher.RelatedArticlesByNNSearcher" bundle="cord-19"/>
+            <searcher id="ai.vespa.example.cord19.searcher.BoldingSearcher" bundle="cord-19"/>
           </chain>
 
         </search>

--- a/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/BoldingSearcher.java
+++ b/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/BoldingSearcher.java
@@ -1,0 +1,42 @@
+package ai.vespa.example.cord19.searcher;
+import com.yahoo.prelude.query.CompositeItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.PhraseItem;
+import com.yahoo.prelude.query.WordItem;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+
+/**
+ * This searcher traverse the query tree and looks for known stopwords, the stopwords are annotated with filter which will avoid
+ * bolding them in the search result
+ */
+
+public class BoldingSearcher extends Searcher {
+
+
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        setFilterForStopWords(query.getModel().getQueryTree().getRoot());
+        return execution.search(query);
+    }
+
+    private void setFilterForStopWords(Item item) {
+        if (item instanceof WordItem) {
+            String word = ((WordItem)item).getWord();
+            word = word.toLowerCase();
+            if (RelatedArticlesByWeakAndSearcher.stopwords.contains(word) ) {
+                item.setFilter(true);
+            }
+        } else if (item instanceof PhraseItem) {
+            return;
+        }
+        else if (item instanceof CompositeItem) {
+            CompositeItem cItem = (CompositeItem)item;
+            for (Item i : cItem.items())
+                setFilterForStopWords(i);
+        }
+    }
+}

--- a/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/RelatedArticlesByWeakAndSearcher.java
+++ b/vespa-cloud/cord-19-search/src/main/java/ai/vespa/example/cord19/searcher/RelatedArticlesByWeakAndSearcher.java
@@ -97,7 +97,7 @@ public class RelatedArticlesByWeakAndSearcher extends RelatedArticlesSearcher {
         query.getModel().getQueryTree().setRoot(andItem);
     }
 
-    private static Set<String> stopwords = Set.of(
+    protected static Set<String> stopwords = Set.of(
                 "i", "me", "my", "myself", "we", "our", "ours", "ourselves",
                 "you", "your", "yours", "yourself", "yourselves", "he", "him", "his", "himself", "she", "her", "hers",
                 "herself", "it", "its", "itself", "they", "them", "their", "theirs", "themselves", "what", "which", "who", "whom",

--- a/vespa-cloud/cord-19-search/src/test/java/ai/vespa/example/cord19/searcher/BoldingSearcherTest.java
+++ b/vespa-cloud/cord-19-search/src/test/java/ai/vespa/example/cord19/searcher/BoldingSearcherTest.java
@@ -1,0 +1,34 @@
+package ai.vespa.example.cord19.searcher;
+
+import com.yahoo.component.chain.Chain;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BoldingSearcherTest {
+
+    @Test
+    public void testThatStopWordIsAnnotedAsFilter(){
+        Query input = new Query("?query=basic+reproduction+numbers+For+covid-19+IN+%22south+korea%22&type=any");
+        Result result = execute(input, new BoldingSearcher());
+        assertEquals("OR basic reproduction numbers |For (AND covid 19) |IN \"south korea\"",
+                result.getQuery().getModel().getQueryTree().toString());
+
+    }
+    @Test
+    public void testThatPhraseUntouched(){
+        Query input = new Query("?query=temperature+%22impact+on%22+viral+transmission&type=any");
+        Result result = execute(input, new BoldingSearcher());
+        assertEquals("OR temperature \"impact on\" viral transmission",
+                result.getQuery().getModel().getQueryTree().toString());
+
+    }
+
+    private Result execute(Query query, Searcher... searcher) {
+        Execution execution = new Execution(new Chain<>(searcher), Execution.Context.createContextStub());
+        return execution.search(query);
+    }
+}


### PR DESCRIPTION
This PR sets query terms which are found in the stopword list as filter terms, they are still ranked but not bolded in the search results. With long question type queries the highlighting of stopwords becomes very noisy, consider screenshot below. 

![image](https://user-images.githubusercontent.com/20928528/79150550-418ed680-7dc9-11ea-97aa-0bcfa0d5d5e5.png)



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
