### PR TITLE
Kkraune/text search fix

### DIFF
--- a/text-search/README.md
+++ b/text-search/README.md
@@ -63,7 +63,6 @@ $ curl -s 'http://localhost:8080/search/?query=what+is+dad+bod'
 **Install python dependencies:**
 
 <pre data-test="exec">
-pip3 install -qqq --upgrade --force-reinstall pip
 pip3 install -qqq -r src/python/requirements.txt
 </pre>
 

--- a/text-search/README.md
+++ b/text-search/README.md
@@ -63,7 +63,7 @@ $ curl -s 'http://localhost:8080/search/?query=what+is+dad+bod'
 **Install python dependencies:**
 
 <pre data-test="exec">
-pip3 install -qqq -r src/python/requirements.txt
+pip3 install -r src/python/requirements.txt
 </pre>
 
 **Collect training data:**


### PR DESCRIPTION
lesters FYI

    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=572 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/include/python3.6m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.6/psutil/_psutil_common.o
    unable to execute 'gcc': No such file or directory