### PR TITLE
Swarm example enhancements

### DIFF
--- a/basic-search-on-docker-swarm/docker-compose.yml
+++ b/basic-search-on-docker-swarm/docker-compose.yml
@@ -1,11 +1,11 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 version: '3.7'
 services:
-  cfg1:
+  config0:
     image: vespaengine/vespa
-    hostname: "cfg1.vespa_net"
+    hostname: "config0.vespa_net"
     environment:
-      - VESPA_CONFIGSERVERS=cfg1.vespa_net,cfg2.vespa_net,cfg3.vespa_net
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
     ports:
       - target: 19071
         published: 19071
@@ -16,37 +16,34 @@ services:
       - data:/opt/vespa/var
       - logs:/opt/vespa/logs
 
-  cfg2:
+  config1:
     image: vespaengine/vespa
-    hostname: "cfg2.vespa_net"
+    hostname: "config1.vespa_net"
     environment:
-      - VESPA_CONFIGSERVERS=cfg1.vespa_net,cfg2.vespa_net,cfg3.vespa_net
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
     networks:
       - net
     volumes:
       - data:/opt/vespa/var
       - logs:/opt/vespa/logs
 
-  cfg3:
+  config2:
     image: vespaengine/vespa
-    hostname: "cfg3.vespa_net"
+    hostname: "config2.vespa_net"
     environment:
-      - VESPA_CONFIGSERVERS=cfg1.vespa_net,cfg2.vespa_net,cfg3.vespa_net
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
     networks:
       - net
     volumes:
       - data:/opt/vespa/var
       - logs:/opt/vespa/logs
 
-  container:
+  container0:
     image: vespaengine/vespa
     command: services
-    hostname: "{{.Service.Name}}.{{.Task.Slot}}.{{.Task.ID}}.vespa_net"
+    hostname: "container0.vespa_net"
     environment:
-      - VESPA_CONFIGSERVERS=cfg1.vespa_net,cfg2.vespa_net,cfg3.vespa_net
-    deploy:
-       mode: replicated
-       replicas: 1
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
     ports:
       - target: 8080
         published: 8080
@@ -57,15 +54,68 @@ services:
       - data:/opt/vespa/var
       - logs:/opt/vespa/logs
 
-  content:
+  container1:
     image: vespaengine/vespa
     command: services
-    hostname: "{{.Service.Name}}.{{.Task.Slot}}.{{.Task.ID}}.vespa_net"
+    hostname: "container1.vespa_net"
     environment:
-      - VESPA_CONFIGSERVERS=cfg1.vespa_net,cfg2.vespa_net,cfg3.vespa_net
-    deploy:
-       mode: replicated
-       replicas: 3
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
+    ports:
+      - target: 8080
+        published: 8081
+        mode: host
+    networks:
+      - net
+    volumes:
+      - data:/opt/vespa/var
+      - logs:/opt/vespa/logs
+
+  container2:
+    image: vespaengine/vespa
+    command: services
+    hostname: "container2.vespa_net"
+    environment:
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
+    ports:
+      - target: 8080
+        published: 8082
+        mode: host
+    networks:
+      - net
+    volumes:
+      - data:/opt/vespa/var
+      - logs:/opt/vespa/logs
+
+  content0:
+    image: vespaengine/vespa
+    command: services
+    hostname: "content0.vespa_net"
+    environment:
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
+    networks:
+      - net
+    volumes:
+      - data:/opt/vespa/var
+      - logs:/opt/vespa/logs
+
+  content1:
+    image: vespaengine/vespa
+    command: services
+    hostname: "content1.vespa_net"
+    environment:
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
+    networks:
+      - net
+    volumes:
+      - data:/opt/vespa/var
+      - logs:/opt/vespa/logs
+
+  content2:
+    image: vespaengine/vespa
+    command: services
+    hostname: "content2.vespa_net"
+    environment:
+      - VESPA_CONFIGSERVERS=config0.vespa_net,config1.vespa_net,config2.vespa_net
     networks:
       - net
     volumes:

--- a/basic-search-on-docker-swarm/scripts/deploy.sh
+++ b/basic-search-on-docker-swarm/scripts/deploy.sh
@@ -6,7 +6,7 @@ set -x
 readonly MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $MYDIR
 
-readonly SID=$(tar -C ../src/main/application -cf - . | gzip | curl -s -L --header "Content-Type: application/x-gzip" --data-binary @- "$(hostname):19071/application/v2/tenant/default/session" | python -c "import sys,json; print json.load(sys.stdin)['session-id'];")
+readonly SID=$(tar -C ../src/main/application -cf - . | gzip | curl -s -L --header "Content-Type: application/x-gzip" --data-binary @- "$(hostname):19071/application/v2/tenant/default/session" | python -c "import sys,json; print(json.load(sys.stdin)['session-id']);")
 curl -s -L -X PUT "$(hostname):19071/application/v2/tenant/default/session/$SID/prepared" | python -mjson.tool
 curl -s -L -X PUT "$(hostname):19071/application/v2/tenant/default/session/$SID/active" | python -mjson.tool
 

--- a/basic-search-on-docker-swarm/scripts/feed.sh
+++ b/basic-search-on-docker-swarm/scripts/feed.sh
@@ -6,10 +6,10 @@ set -x
 readonly MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $MYDIR
 
-while  ! curl -s "http://$(hostname):8080/search/?query=bad" | python -c "import sys,json; print json.load(sys.stdin)['root']['coverage'];" &> /dev/null; do
+while  ! curl -s "http://$(hostname):8080/search/?query=bad" | python -c "import sys,json; print(json.load(sys.stdin)['root']['coverage']);" &> /dev/null; do
     echo "Search backend not up yet. Sleeping 5 seconds."
     sleep 5
-done    
+done
 
 curl -s -L -H "Content-Type:application/json" --data-binary @../music-data-1.json "http://$(hostname):8080/document/v1/music/music/docid/1" | python -m json.tool
 curl -s -L -H "Content-Type:application/json" --data-binary @../music-data-2.json "http://$(hostname):8080/document/v1/music/music/docid/2" | python -m json.tool

--- a/basic-search-on-docker-swarm/scripts/generate_hosts_xml.sh
+++ b/basic-search-on-docker-swarm/scripts/generate_hosts_xml.sh
@@ -3,13 +3,15 @@
 set -euo pipefail
 
 get_hosts() {
-  docker stack ps --no-trunc --filter "desired-state=running" vespa | grep "vespaengine/vespa" | awk '{print $2"."$1.".vespa_net"}'
+  docker stack ps --no-trunc --filter "desired-state=running" vespa | grep "vespaengine/vespa" | awk '{print $2""}'
 }
 
-echo '<?xml version="1.0" encoding="utf-8" ?>' 
+echo '<?xml version="1.0" encoding="utf-8" ?>'
 echo '<hosts>'
-I=0; for n in $(seq 1 3); do echo "  <host name='cfg$n.vespa_net'><alias>config$I</alias></host>"; I=$(($I + 1)); done
-I=0; for h in $(get_hosts|grep content|sort); do echo "  <host name='$h'><alias>content$I</alias></host>"; I=$(($I + 1)); done
-I=0; for h in $(get_hosts|grep container|sort); do echo "  <host name='$h'><alias>container$I</alias></host>"; I=$(($I + 1)); done
+for h in $(get_hosts|sort); do
+  h="${h%.[0-9]*}"
+  h="${h#*_}"
+  echo "  <host name='${h}.vespa_net'><alias>${h}</alias></host>"
+done
 echo '</hosts>'
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Rework docker-compose for the following enhancements:
- names don't change when containers restart, so hosts.xml stays valid.
- names can be aligned with aliases, so generate_hosts_xml.sh is simpler.
- containers are kept separate so port bindings can be set individually.
- each container can be constrained to a specific node, so in a cluster we have control on their repartition.

generate_hosts_xml.sh is adapted accordingly.

On top of that, the syntax for python code in scripts has been updated for python 3 compatibility.