### PR TITLE
Revert "make deployable"

### DIFF
--- a/vespa-cloud/cord-19-search/src/test/java/ai/vespa/example/cord19/searcher/RelatedArticlesByWeakAndSearcherTest.java
+++ b/vespa-cloud/cord-19-search/src/test/java/ai/vespa/example/cord19/searcher/RelatedArticlesByWeakAndSearcherTest.java
@@ -9,7 +9,6 @@ import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +32,6 @@ public class RelatedArticlesByWeakAndSearcherTest {
     }
 
     @Test
-    @Disabled
     public void testRelatedToTitleOnly() {
         Query query = new Query("?query=covid-19+%2B%22south+korea%22+%2Brelated_to:123&type=any&use-abstract=false");
         Result result = execute(query, new RelatedArticlesByWeakAndSearcher(new SimpleLinguistics()), new MockBackend());
@@ -42,7 +40,6 @@ public class RelatedArticlesByWeakAndSearcherTest {
     }
 
     @Test
-    @Disabled
     public void testRelatedToTitleAndAbstract() {
         Query query = new Query("?query=covid-19+%2B%22south+korea%22+%2Brelated_to:123&type=any&use-abstract=true");
         Result result = execute(query, new RelatedArticlesByWeakAndSearcher(new SimpleLinguistics()), new MockBackend());


### PR DESCRIPTION
Reverts vespa-engine/sample-apps#512 - as it is deployed, both code and Vespa is on the latest and greatest, so can enable tests again