### PR TITLE
use less resources

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/services.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/services.xml
@@ -32,7 +32,7 @@
     </document-processing>
 
     <nodes count="[2,4]">
-      <resources memory="16Gb" vcpu="8" disk="100Gb" disk-speed="fast"/>
+      <resources memory="8Gb" vcpu="4" disk="50Gb" disk-speed="fast"/>
     </nodes>
   </container>
 
@@ -61,7 +61,7 @@
       <document-processing cluster="default" chain="bert-tensorizer" />
     </documents>
     <nodes count="[2,4]">
-      <resources memory="16Gb" vcpu="8" disk="100Gb" disk-speed="fast"/>
+      <resources memory="8Gb" vcpu="4" disk="50Gb" disk-speed="fast"/>
     </nodes>
   </content>
 </services>


### PR DESCRIPTION
- content cluster: Won't autoscale now: Less than PT36H52M39.074666666S since last resource change
- container cluster: Cluster is ideally scaled within configured limits

lets try it now, it should just swap the two nodes in each cluster with smaller ones