### PR TITLE
try local disk

### DIFF
--- a/vespa-cloud/search-suggestion/src/main/application/services.xml
+++ b/vespa-cloud/search-suggestion/src/main/application/services.xml
@@ -37,8 +37,8 @@
             <document mode="streaming" type="query"/>
             <document mode="streaming" type="term"/>
         </documents>
-        <nodes count="[2,3]">
-            <resources vcpu="2.0" memory="8Gb" disk="50Gb" storage-type="local" />
+        <nodes count="2">
+            <resources vcpu="2.0" memory="4Gb" disk="50Gb" storage-type="local" />
         </nodes>
     </content>
 


### PR DESCRIPTION
Based on:

> Failed to prepare application: Invalid application package: Error loading vespa-team.search-suggestion: No allocation possible within limits: from 2 nodes with [vcpu: 2.0, memory: 8.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local] to 3 nodes with [vcpu: 2.0, memory: 8.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local]. Nearest allowed node resources: [vcpu: 2.0, memory: 4.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local]
