### PR TITLE
Deploy with a valid resource config

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/services.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/services.xml
@@ -61,7 +61,7 @@
       <document-processing cluster="default" chain="bert-tensorizer" />
     </documents>
     <nodes count="[2,4]">
-      <resources memory="8Gb" vcpu="4" disk="50Gb" storage-type="local" />
+      <resources memory="8Gb" vcpu="4" disk="100Gb" storage-type="local" />
     </nodes>
   </content>
 </services>


### PR DESCRIPTION
Got this when deploying:

> Failed to prepare application: Invalid application package: Error loading vespa-team.cord-19: No allocation possible within limits: from 2 nodes with [vcpu: 4.0, memory: 8.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local] to 4 nodes with [vcpu: 4.0, memory: 8.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local]. Nearest allowed node resources: [vcpu: 2.0, memory: 4.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, storage type: local]

So I think a 100G disk will do.

(But surprised why the deployment fails here, this is from a system test run that anyway is downscaled and uses default resources. But in a way better to fail early :-)