### PR TITLE
Ids in documents

### DIFF
--- a/album-recommendation-selfhosted/src/test/resources/A-Head-Full-of-Dreams.json
+++ b/album-recommendation-selfhosted/src/test/resources/A-Head-Full-of-Dreams.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::a-head-full-of-dreams",
     "fields": {
         "album": "A Head Full of Dreams",
         "artist": "Coldplay",

--- a/album-recommendation-selfhosted/src/test/resources/Hardwired...To-Self-Destruct.json
+++ b/album-recommendation-selfhosted/src/test/resources/Hardwired...To-Self-Destruct.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::hardwired-to-self-destruct",
     "fields": {
         "album": "Hardwired...To Self-Destruct",
         "artist": "Metallica",

--- a/album-recommendation-selfhosted/src/test/resources/Liebe-ist-fur-alle-da.json
+++ b/album-recommendation-selfhosted/src/test/resources/Liebe-ist-fur-alle-da.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::liebe-ist-für-alle-da",
     "fields": {
         "album": "Liebe ist für alle da",
         "artist": "Rammstein",

--- a/album-recommendation-selfhosted/src/test/resources/Love-Is-Here-To-Stay.json
+++ b/album-recommendation-selfhosted/src/test/resources/Love-Is-Here-To-Stay.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::love-id-here-to-stay",
     "fields": {
         "album": "Love Is Here To Stay",
         "artist": "Diana Krall",

--- a/album-recommendation-selfhosted/src/test/resources/When-We-All-Fall-Asleep-Where-Do-We-Go.json
+++ b/album-recommendation-selfhosted/src/test/resources/When-We-All-Fall-Asleep-Where-Do-We-Go.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::when-we-all-fall-asleep-where-do-we-go",
     "fields": {
         "album": "When We All Fall Asleep, Where Do We Go?",
         "artist": "Billie Eilish",

--- a/basic-search-on-gke/music-data-1.json
+++ b/basic-search-on-gke/music-data-1.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::bad",
     "fields": {
          "album": "Bad",
          "artist": "Michael Jackson",

--- a/basic-search-on-gke/music-data-2.json
+++ b/basic-search-on-gke/music-data-2.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::recovery",
     "fields": {
         "album": "Recovery",
         "artist": "Eminem",

--- a/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/DocTypeDocProcTest.java
+++ b/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/DocTypeDocProcTest.java
@@ -39,9 +39,9 @@ public class DocTypeDocProcTest {
         DocumentType docType = createMusicDocumentType();
         DocumentTypeManager typeMgr = new DocumentTypeManager(new DocumentmanagerConfig.Builder().build());
         typeMgr.registerDocumentType(docType);
-        DocumentOperation op = docProc.createDocFromJson(typeMgr,"id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::1");
+        DocumentOperation op = docProc.createDocFromJson(typeMgr,"id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::a-head-full-of-dreams");
 
-        assertEquals("put of document id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::1", op.toString());
+        assertEquals("put of document id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::a-head-full-of-dreams", op.toString());
     }
 
     /**
@@ -59,7 +59,7 @@ public class DocTypeDocProcTest {
 
         Processing processing = new Processing();
         Document doc = new Document(container.documentProcessing().getDocumentTypes().get(MUSIC_DOCUMENT_TYPE),
-                "id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::1");
+                "id:mynamespace:" + MUSIC_DOCUMENT_TYPE + "::a-head-full-of-dreams");
         processing.addDocumentOperation(new DocumentPut(doc));
         container.documentProcessing().processOnce(ComponentSpecification.fromString("myChain"), processing);
 

--- a/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/ProductTypeRefinerDocProcTest.java
+++ b/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/ProductTypeRefinerDocProcTest.java
@@ -48,7 +48,7 @@ class ProductTypeRefinerDocProcTest {
 
     @Test
     public void testRefinement() {
-        Document doc = new Document(createMusicType(), "id:mynamespace:music::1");
+        Document doc = new Document(createMusicType(), "id:mynamespace:music::a-head-full-of-dreams");
         doc.setFieldValue(PRODUCT_TYPE_FIELD_NAME,
                 new StringFieldValue("Media > Music & Sound Recordings > Music Cassette Tapes"));
 

--- a/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/ProductTypeTokenizerDocProcTest.java
+++ b/vespa-cloud/album-recommendation-docproc/src/test/java/ai/vespa/example/album/ProductTypeTokenizerDocProcTest.java
@@ -50,7 +50,7 @@ class ProductTypeTokenizerDocProcTest {
 
     @Test
     public void testTokenizer() {
-        Document doc = new Document(createMusicType(), "id:mynamespace:music::1");
+        Document doc = new Document(createMusicType(), "id:mynamespace:music::a-head-full-of-dreams");
         doc.setFieldValue(PRODUCT_TYPE_FIELD_NAME,
                 new StringFieldValue("Media > Music & Sound Recordings > Music Cassette Tapes"));
 

--- a/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams-lyrics.json
+++ b/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams-lyrics.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:lyrics::a-head-full-of-dreams",
     "fields": {
         "song_lyrics": "Oh, I think I landed In a world I hadn't seen When I'm feeling ordinary"
     }

--- a/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams-product.json
+++ b/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams-product.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::a-head-full-of-dreams",
     "fields": {
         "album": "A Head Full of Dreams",
         "artist": "Coldplay",

--- a/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams.json
+++ b/vespa-cloud/album-recommendation-docproc/src/test/resources/A-Head-Full-of-Dreams.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::a-head-full-of-dreams",
     "fields": {
         "album": "A Head Full of Dreams",
         "artist": "Coldplay",

--- a/vespa-cloud/album-recommendation-docproc/src/test/resources/Hardwired...To-Self-Destruct.json
+++ b/vespa-cloud/album-recommendation-docproc/src/test/resources/Hardwired...To-Self-Destruct.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::hardwired-to-self-desctruct",
     "fields": {
         "album": "Hardwired...To Self-Destruct",
         "artist": "Metallica",

--- a/vespa-cloud/album-recommendation-docproc/src/test/resources/Love-Is-Here-To-Stay.json
+++ b/vespa-cloud/album-recommendation-docproc/src/test/resources/Love-Is-Here-To-Stay.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::love-id-here-to-stay",
     "fields": {
         "album": "Love Is Here To Stay",
         "artist": "Diana Krall",

--- a/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/FeedAndSearchSystemTest.java
+++ b/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/FeedAndSearchSystemTest.java
@@ -29,7 +29,7 @@ class FeedAndSearchSystemTest {
 
     @Test
     void feedAndSearch() throws IOException {
-        String documentPath = "/document/v1/mynamespace/music/docid/Got-to-be-there";
+        String documentPath = "/document/v1/mynamespace/music/docid/got-to-be-there";
         String document = "{\n" +
                           "    \"fields\": {\n" +
                           "         \"album\": \"Got to be there\"\n" +
@@ -42,8 +42,9 @@ class FeedAndSearchSystemTest {
         assertEquals(200, deleteResult.statusCode());
 
         // the first query needs a higher timeout than the default 500ms, to warm up the code
-        HttpResponse<String> emptyResult = endpoint.send(endpoint.request("/search/", Map.of("yql", yql,
-                                                                            "timeout", "5s")));
+        HttpResponse<String> emptyResult = endpoint.send(endpoint.request("/search/",
+                                                                          Map.of("yql", yql,
+                                                                                 "timeout", "5s")));
         assertEquals(200, emptyResult.statusCode());
         assertEquals(0, new ObjectMapper().readTree(emptyResult.body())
                 .get("root").get("fields").get("totalCount").asLong());
@@ -52,7 +53,8 @@ class FeedAndSearchSystemTest {
                                                .POST(ofString(document)));
         assertEquals(200, feedResult.statusCode());
 
-        HttpResponse<String> searchResult = endpoint.send(endpoint.request("/search/", Map.of("yql", yql)));
+        HttpResponse<String> searchResult = endpoint.send(endpoint.request("/search/",
+                                                                           Map.of("yql", yql)));
         assertEquals(200, searchResult.statusCode());
         assertEquals(1, new ObjectMapper().readTree(searchResult.body())
                 .get("root").get("fields").get("totalCount").asLong());

--- a/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/MetalProductionTest.java
+++ b/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/MetalProductionTest.java
@@ -11,7 +11,7 @@ public class MetalProductionTest {
 
     @Test
     void dummyTest() {
-        assertEquals("Prod is all right!","Prod is all right!");
+        assertEquals("Prod is all right!", "Prod is all right!");
     }
 
 }

--- a/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/MetalSearcherTest.java
+++ b/vespa-cloud/album-recommendation-searcher/src/test/java/ai/vespa/example/album/MetalSearcherTest.java
@@ -60,7 +60,6 @@ class MetalSearcherTest {
 
     @Test
     void testAddedOrTerm1() {
-
         MetalNamesConfig.Builder builder = new MetalNamesConfig.Builder();
         builder.metalWords(Arrays.asList("hetfield", "metallica", "pantera"));
         MetalNamesConfig config = new MetalNamesConfig(builder);
@@ -75,10 +74,8 @@ class MetalSearcherTest {
         assertAddedOrTerm(metalQuery.getModel().getQueryTree().getRoot());
     }
 
-
     @Test
     void testAddedOrTerm2() {
-
         try (Application app = Application.fromApplicationPackage(
                 FileSystems.getDefault().getPath("src/main/application"),
                 Networking.disable)) {
@@ -90,10 +87,8 @@ class MetalSearcherTest {
         }
     }
 
-
     @Test
     void testWithMockBackendProducingHits() {
-
         DocumentSourceSearcher docSource = new DocumentSourceSearcher();
         Query testQuery = new Query();
         testQuery.setTraceLevel(6);

--- a/vespa-cloud/album-recommendation-searcher/src/test/resources/A-Head-Full-of-Dreams.json
+++ b/vespa-cloud/album-recommendation-searcher/src/test/resources/A-Head-Full-of-Dreams.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::a-head-full-of-dreams",
     "fields": {
         "album": "A Head Full of Dreams",
         "artist": "Coldplay",

--- a/vespa-cloud/album-recommendation-searcher/src/test/resources/Hardwired...To-Self-Destruct.json
+++ b/vespa-cloud/album-recommendation-searcher/src/test/resources/Hardwired...To-Self-Destruct.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::hardwired-to-self-destruct",
     "fields": {
         "album": "Hardwired...To Self-Destruct",
         "artist": "Metallica",

--- a/vespa-cloud/album-recommendation-searcher/src/test/resources/Love-Is-Here-To-Stay.json
+++ b/vespa-cloud/album-recommendation-searcher/src/test/resources/Love-Is-Here-To-Stay.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::love-id-here-to-stay",
     "fields": {
         "album": "Love Is Here To Stay",
         "artist": "Diana Krall",

--- a/vespa-cloud/album-recommendation/src/test/resources/A-Head-Full-of-Dreams.json
+++ b/vespa-cloud/album-recommendation/src/test/resources/A-Head-Full-of-Dreams.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::a-head-full-of-dreams",
     "fields": {
         "album": "A Head Full of Dreams",
         "artist": "Coldplay",

--- a/vespa-cloud/album-recommendation/src/test/resources/Hardwired...To-Self-Destruct.json
+++ b/vespa-cloud/album-recommendation/src/test/resources/Hardwired...To-Self-Destruct.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::hardwired-to-self-destruct",
     "fields": {
         "album": "Hardwired...To Self-Destruct",
         "artist": "Metallica",

--- a/vespa-cloud/album-recommendation/src/test/resources/Love-Is-Here-To-Stay.json
+++ b/vespa-cloud/album-recommendation/src/test/resources/Love-Is-Here-To-Stay.json
@@ -1,4 +1,5 @@
 {
+    "put": "id:mynamespace:music::love-id-here-to-stay",
     "fields": {
         "album": "Love Is Here To Stay",
         "artist": "Diana Krall",


### PR DESCRIPTION
- Put id's in documents to make cli commands nicer
- Use text ids to avoid any beginner confusion about having to
  generate numeric ids
