### PR TITLE
Add timing and replace OR with weakAnd

### DIFF
--- a/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/default.xml
+++ b/vespa-cloud/cord-19-search/src/main/application/search/query-profiles/default.xml
@@ -3,4 +3,6 @@
  <field name="maxHits">1000</field>
  <field name="maxOffset">1000</field> 
  <field name="timeout">2s</field>
+ <field name="presentation.timing">true</field>
+ <field name="weakAnd.replace">true</field>
 </query-profile>


### PR DESCRIPTION
- Speeds up search by 20x as less candidates are exposed to first phase function and grouping framework. Typical response improvement from 1 second to 50 ms. 
- Added presentation timing information to add to frontend

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
