### PR TITLE
Add DPR sample app in testing of sample apps

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -15,6 +15,7 @@ urls:
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/incremental-search/search-suggestions/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/vespa-cloud/vespa-documentation-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/vespa-cloud/cord-19-search/README.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/dense-passage-retrieval-with-ann/README.md"
     #
     # TBD:
     # - secure-vespa-with-mtls
@@ -26,7 +27,6 @@ urls:
     #
     #
     # Disable for now - downloads large models
-    # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/dense-passage-retrieval-with-ann/README.md"
     # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/semantic-qa-retrieval/README.md"
     #
     #


### PR DESCRIPTION
This works fine locally. 

But it requires torch which is large (800 MB or so), plus 2x 400MB models.  If screwdriver.cd does not handle downloads of these models and we cannot test the sample app we must look into how we can test this app as part of our CI/CD. 

```
python3 test.py -v ../dense-passage-retrieval-with-ann/README.md 


********************************************************************************
* curl -s "http://localhost:8080/search/?query=what+is+the+population+of+achill+island%3F" | python -m json.tool
* (Expecting 'prediction": "2, 700"')
********************************************************************************
{
    "root": {
        "id": "toplevel",
        "relevance": 1.0,
        "fields": {
            "totalCount": 10
        },
        "coverage": {
            "coverage": 100,
            "documents": 100,
            "full": true,
            "nodes": 1,
            "results": 1,
            "resultsFull": 1
        },
        "children": [
            {
                "id": "answer",
                "relevance": 1.0,
                "fields": {
                    "prediction": "2, 700",
                    "context": "Achill Island Achill Island (; ) in County Mayo is the largest of the Irish isles, and is situated off the west coast of Ireland. It has a population of 2,700. Its area is . Achill is attached to the mainland by Michael Davitt Bridge, between the villages of Gob an Choire (Achill Sound) and Poll Raithn\u00ed (Polranny). A bridge was first completed here in 1887, replaced by another structure in 1949, and subsequently replaced with the current bridge which was completed in 2008. Other centres of population include the villages of Keel, Dooagh, Dumha \u00c9ige (Dooega), D\u00fan Ibhir (Dooniver),",
                    "context_title": "Achill Island",
                    "prediction_score": 23.630077362060547,
                    "reader_score": 11.106307983398438
                }
            }
        ]
    }
}

********************************************************************************
* curl -s "http://localhost:8080/search/?query=what+is+the+boiling+point+of+ethanol%3F" | python -m json.tool
* (Expecting 'prediction": "78. 29')
********************************************************************************
{
    "root": {
        "id": "toplevel",
        "relevance": 1.0,
        "fields": {
            "totalCount": 10
        },
        "coverage": {
            "coverage": 100,
            "documents": 100,
            "full": true,
            "nodes": 1,
            "results": 1,
            "resultsFull": 1
        },
        "children": [
            {
                "id": "answer",
                "relevance": 1.0,
                "fields": {
                    "prediction": "78. 29 \u00b0 c",
                    "context": "most other compounds. Owing to the presence of the polar OH alcohols are more water-soluble than simple hydrocarbons. Methanol, ethanol, and propanol are miscible in water. Butanol, with a four-carbon chain, is moderately soluble. Because of hydrogen bonding, alcohols tend to have higher boiling points than comparable hydrocarbons and ethers. The boiling point of the alcohol ethanol is 78.29 \u00b0C, compared to 69 \u00b0C for the hydrocarbon hexane, and 34.6 \u00b0C for diethyl ether. Simple alcohols are found widely in nature. Ethanol is most prominent because it is the product of fermentation, a major energy-producing pathway. The other simple alcohols",
                    "context_title": "Alcohol",
                    "prediction_score": 11.94470500946045,
                    "reader_score": 5.619107723236084
                }
            }
        ]
    }
}
```



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
