### PR TITLE
Add more apps to sample application testing 

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -16,22 +16,12 @@ urls:
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/vespa-cloud/vespa-documentation-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/vespa-cloud/cord-19-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/dense-passage-retrieval-with-ann/README.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/semantic-qa-retrieval/README.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/transformers/README.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/msmarco-ranking/passage-ranking.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/msmarco-ranking/document-ranking.md"
+    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/operations/multinode/README.md"
     #
     # TBD:
     # - secure-vespa-with-mtls
     # - basic-search-on-gke
-    #
-    #
-    # Does start the containers, most likely insufficient memory for many containers
-    # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/operations/multinode/README.md"
-    #
-    #
-    # Disable for now - downloads large models
-    # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/semantic-qa-retrieval/README.md"
-    #
-    #
-    # Disable for now: Downloading torch-1.8.1-cp36-cp36m-manylinux1_x86_64.whl (804.1 MB) fails on Screwdriver.cd
-    # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/transformers/README.md"
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/msmarco-ranking/passage-ranking.md"
-    # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/msmarco-ranking/document-ranking.md"
-    #


### PR DESCRIPTION
Hoping that after increasing memory for the tester container https://github.com/vespa-engine/sample-apps/pull/726 this change will just work. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
