### PR TITLE
Use updated Docker image

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -41,7 +41,7 @@ jobs:
     requires: [~commit]
     secrets:
       - VESPA_TEAM_API_KEY
-    image: vespaengine/vespa-pipeline
+    image: vespaengine/pipeline
     environment:
       USER_SHELL_BIN: bash
     annotations:


### PR DESCRIPTION
I think this image is renamed from `vespaengine/vespa-pipeline` to `vespaengine/pipeline` on docker hub - on my local machine:

```
$ docker images
REPOSITORY                            TAG       IMAGE ID       CREATED        SIZE
vespaengine/vespa                     latest    808ff5c4b90c   5 days ago     2.05GB
vespaengine/pipeline                  latest    dcabf96a02a6   13 days ago    520MB
docker.ouroath.com:4443/vespa/rhel8   latest    8978780ab388   3 weeks ago    456MB
vespaengine/vespa-build-centos7       latest    f1fff3731f11   4 weeks ago    2.16GB
vespaengine/vespa-pipeline            latest    ddcd35dbc329   4 months ago   508MB
```

per screwdriver.yaml it is pushed as `docker push docker.io/vespaengine/pipeline:latest `- but the readme says `docker pull vespaengine/vespa-pipeline` - see https://github.com/vespa-engine/docker-image-pipeline

I hence think the sampleapp test image is stale (doc testing, too, but lets try this first) - I cannot really test it locally due to docker in docker, so lets give it a spin

The new image has the vespa-cli installed - guides using this fails now

@jobergum revert this if this screws up your testing, but please merge so we will see if my theory is right - or @aressem 