### PR TITLE
Add example of set filtering

### DIFF
--- a/album-recommendation-java/src/main/application/services.xml
+++ b/album-recommendation-java/src/main/application/services.xml
@@ -2,80 +2,83 @@
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <services version="1.0" xmlns:deploy="vespa" xmlns:preprocess="properties">
 
+  <!--
+      A container cluster handles incoming requests to the application and processes those requests,
+      and their results. The processing to do and the API's to expose can be provides by Vespa
+      or by the application through Java components supplied as part of the application.
+
+      See:
+        - Reference: https://docs.vespa.ai/en/reference/services-container.html
+  -->
+  <container id="default" version="1.0">
     <!--
-        A container cluster handles incoming requests to the application and processes those requests,
-        and their results. The processing to do and the API's to expose can be provides by Vespa
-        or by the application through Java components supplied as part of the application.
+        <document-api> tells the container that it should accept documents for indexing. Through the
+        Document REST API you can PUT new documents, UPDATE existing documents, and DELETE documents
+        already in the cluster.
+
+        Documents sent to the Document REST API will be passed through document processors on the way
+        to the content cluster.
 
         See:
-          - Reference: https://docs.vespa.ai/en/reference/services-container.html
+         - Reference: https://docs.vespa.ai/en/reference/services-container.html#document-api
+         - Operations: https://docs.vespa.ai/en/document-api.html
     -->
-    <container id="default" version="1.0">
-        <!--
-            <document-api> tells the container that it should accept documents for indexing. Through the
-            Document REST API you can PUT new documents, UPDATE existing documents, and DELETE documents
-            already in the cluster.
-
-            Documents sent to the Document REST API will be passed through document processors on the way
-            to the content cluster.
-
-            See:
-             - Reference: https://docs.vespa.ai/en/reference/services-container.html#document-api
-             - Operations: https://docs.vespa.ai/en/document-api.html
-        -->
-        <document-api/>
-
-        <!--
-            <search> tells the container to answers queries and serve results for those queries.
-            Inside the <search /> cluster you can configure chains of "searchers" -
-            Java components processing the query and/or result.
-
-            See:
-             - Reference: https://docs.vespa.ai/en/search-api.html
-             - Searchers: https://docs.vespa.ai/en/searcher-development.html
-        -->
-        <search>
-            <chain id="metalchain" inherits="vespa">
-                <searcher id="ai.vespa.example.album.MetalSearcher" bundle="albums">
-                    <config name="ai.vespa.example.album.metal-names">
-                        <metalWords>
-                            <item>hetfield</item>
-                            <item>metallica</item>
-                            <item>pantera</item>
-                        </metalWords>
-                    </config>
-                </searcher>
-            </chain>
-        </search>
-
-        <!--
-            <nodes> specifies the nodes that should run this cluster, and through the <resources>
-            subtag, the resources on those nodes. You can also specify ranges of nodes and resources
-            to activate autoscaling.
-
-            See:
-             - Reference: https://cloud.vespa.ai/en/reference/services.html
-        -->
-        <nodes>
-            <node hostalias="node1" />
-        </nodes>
-    </container>
+    <document-api/>
 
     <!--
-        <content/> content clusters store application data, maintain indexes and executes the
-        distributed parts of a query.
+        <search> tells the container to answers queries and serve results for those queries.
+        Inside the <search /> cluster you can configure chains of "searchers" -
+        Java components processing the query and/or result.
 
         See:
-          - Reference: https://docs.vespa.ai/en/reference/services-content.html
+         - Reference: https://docs.vespa.ai/en/search-api.html
+         - Searchers: https://docs.vespa.ai/en/searcher-development.html
     -->
-    <content id="music" version="1.0">
-        <redundancy>2</redundancy>
-        <documents>
-            <document type="music" mode="index" />
-        </documents>
-        <nodes>
-            <node hostalias="node1" distribution-key="0" />
-        </nodes>
-    </content>
+    <search>
+      <chain id="default" inherits="vespa">
+        <searcher id="ai.vespa.example.album.SetFilterSearcher" bundle="albums"/>
+      </chain>
+      <chain id="metalchain" inherits="vespa">
+        <searcher id="ai.vespa.example.album.MetalSearcher" bundle="albums">
+          <config name="ai.vespa.example.album.metal-names">
+            <metalWords>
+              <item>hetfield</item>
+              <item>metallica</item>
+              <item>pantera</item>
+            </metalWords>
+          </config>
+        </searcher>
+      </chain>
+    </search>
+
+    <!--
+        <nodes> specifies the nodes that should run this cluster, and through the <resources>
+        subtag, the resources on those nodes. You can also specify ranges of nodes and resources
+        to activate autoscaling.
+
+        See:
+         - Reference: https://cloud.vespa.ai/en/reference/services.html
+    -->
+    <nodes>
+      <node hostalias="node1" />
+    </nodes>
+  </container>
+
+  <!--
+      <content/> content clusters store application data, maintain indexes and executes the
+      distributed parts of a query.
+
+      See:
+        - Reference: https://docs.vespa.ai/en/reference/services-content.html
+  -->
+  <content id="music" version="1.0">
+    <redundancy>2</redundancy>
+    <documents>
+      <document type="music" mode="index" />
+    </documents>
+    <nodes>
+      <node hostalias="node1" distribution-key="0" />
+    </nodes>
+  </content>
 
 </services>

--- a/album-recommendation-java/src/main/application/services.xml
+++ b/album-recommendation-java/src/main/application/services.xml
@@ -57,7 +57,7 @@
         to activate autoscaling.
 
         See:
-         - Reference: https://cloud.vespa.ai/en/reference/services.html
+         - Reference: https://docs.vespa.ai/en/reference/services.html
     -->
     <nodes>
       <node hostalias="node1" />

--- a/album-recommendation-java/src/main/java/ai/vespa/example/album/MetalSearcher.java
+++ b/album-recommendation-java/src/main/java/ai/vespa/example/album/MetalSearcher.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.example.album;
 
 import com.google.inject.Inject;

--- a/album-recommendation-java/src/main/java/ai/vespa/example/album/SetFilterSearcher.java
+++ b/album-recommendation-java/src/main/java/ai/vespa/example/album/SetFilterSearcher.java
@@ -1,0 +1,63 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.example.album;
+
+import com.yahoo.component.chain.dependencies.After;
+import com.yahoo.prelude.query.AndItem;
+import com.yahoo.prelude.query.Item;
+import com.yahoo.prelude.query.WeightedSetItem;
+import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+
+/**
+ * Searcher which accepts a input set filter which which bypass YQL parsing of large set
+ * filters https://docs.vespa.ai/en/performance/feature-tuning.html#multi-lookup-set-filtering
+ *
+ * Example usage
+ *
+ * /search/?yql=select * from music where userQuery()&
+ * set-filter=2015,2016,2018&
+ * set-filter-field-name=year&query=artist:metallica
+ *
+ * The set filter is ANDed with the YQL parts of the query
+ *
+ * Above example is turned into
+ * select * from music where (artist contains "metallica") AND
+ * ([{"filter": true, "ranked": false}]weightedSet(year, {"2015": 1, "2016": 1, "2018": 1}));
+ *
+ */
+
+@After("ExternalYql")
+public class SetFilterSearcher extends Searcher {
+
+    static CompoundName setFilterValues = new CompoundName("set-filter");
+    static CompoundName setFilterFieldName = new CompoundName("set-filter-field-name");
+
+    @Override
+    public Result search(Query query, Execution execution) {
+        String fieldName = query.properties().getString(setFilterFieldName);
+        String values = query.properties().getString(setFilterValues);
+        if(fieldName == null || values == null) {
+            return execution.search(query);
+        }
+        String[] filters = values.split(",");
+        WeightedSetItem setItem = new WeightedSetItem(fieldName);
+        setItem.setFilter(true);
+        setItem.setRanked(false);
+        for(String f: filters) {
+            setItem.addToken(f);
+        }
+        Item queryRoot = query.getModel().getQueryTree().getRoot();
+        if (queryRoot instanceof AndItem) {
+            ((AndItem) queryRoot).addItem(setItem);
+        } else {
+            AndItem and = new AndItem();
+            and.addItem(queryRoot);
+            and.addItem(setItem);
+            query.getModel().getQueryTree().setRoot(and);
+        }
+        return execution.search(query);
+    }
+}

--- a/album-recommendation-java/src/test/java/ai/vespa/example/album/EquivSearcherTest.java
+++ b/album-recommendation-java/src/test/java/ai/vespa/example/album/EquivSearcherTest.java
@@ -1,5 +1,4 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
 package ai.vespa.example.album;
 
 import com.yahoo.component.chain.Chain;
@@ -9,7 +8,6 @@ import com.yahoo.search.Searcher;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.yql.MinimalQueryInserter;
 import org.junit.jupiter.api.Test;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 

--- a/album-recommendation-java/src/test/java/ai/vespa/example/album/MetalSearcherTest.java
+++ b/album-recommendation-java/src/test/java/ai/vespa/example/album/MetalSearcherTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.example.album;
 
 import com.yahoo.application.Application;

--- a/album-recommendation-java/src/test/java/ai/vespa/example/album/SetFilterSearcherTest.java
+++ b/album-recommendation-java/src/test/java/ai/vespa/example/album/SetFilterSearcherTest.java
@@ -1,0 +1,31 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.example.album;
+
+import com.yahoo.component.chain.Chain;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.search.yql.MinimalQueryInserter;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static java.net.URLEncoder.encode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SetFilterSearcherTest {
+
+    @Test
+    public void test_set_filter()   {
+        Chain<Searcher> myChain = new Chain<>(new MinimalQueryInserter(), new SetFilterSearcher());
+        Execution.Context context = Execution.Context.createContextStub();
+        Execution execution = new Execution(myChain, context);
+        String yql = encode("select * from sources * where artist contains \"metallica\";",
+                StandardCharsets.UTF_8);
+        Query query = new Query("/search/?yql=" + yql + "&set-filter=2018,2017&set-filter-field-name=year");
+        Result result = execution.search(query);
+        assertEquals("query \'AND artist:metallica |WEIGHTEDSET year{[1]:\"2018\",[1]:\"2017\"}\'",
+                result.getQuery().toString());
+    }
+}


### PR DESCRIPTION
Added a simple example of how to do set filtering since YQL parsing of large (1000's) keys using weighted set yql query operator is costly. 


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
