### PR TITLE
Ensure Java binary from JAVA_HOME is first on path

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -53,6 +53,7 @@ jobs:
     steps:
       - install-deps: |
           source /etc/profile.d/jdk-env.sh
+          export PATH="$JAVA_HOME/bin:$PATH"
           yum install -y python36-pip
           python3 -m pip install -qqq --upgrade pip
           python3 -m pip install -qqq -r test/requirements.txt --user


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
