### PR TITLE
Revert "test multinode-HA"

### DIFF
--- a/test/_test_config.yml
+++ b/test/_test_config.yml
@@ -1,7 +1,6 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 urls:
-    - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/operations/multinode-HA/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/boolean-search/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/generic-request-processing/README.md"
     - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/http-api-using-request-handlers-and-processors/README.md"
@@ -24,5 +23,6 @@ urls:
     #Fails due to unknown reason, maybe related to multiple docker containers?
     # - "https://raw.githubusercontent.com/vespa-engine/sample-apps/master/operations/multinode/README.md"
     # TBD:
+    # - operations/multinode-HA
     # - operations/secure-vespa-with-mtls
     # - basic-search-on-gke


### PR DESCRIPTION
Reverts vespa-engine/sample-apps#808 - docker crashed, I think we run on max settings - I think we should look into shrinking some containers, we start 10 nodes in separate docker containers here