### PR TITLE
Verbose test run

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -68,4 +68,4 @@ jobs:
       - run-tests: |
           export VESPA_TEAM_API_KEY
           cd $SD_DIND_SHARE_PATH
-          $SD_SOURCE_DIR/test/test.py -c $SD_SOURCE_DIR/test/_test_config.yml
+          $SD_SOURCE_DIR/test/test.py -v -c $SD_SOURCE_DIR/test/_test_config.yml


### PR DESCRIPTION
- the multinode-HA failed at the last step (starting content nodes)
- presumably OOM, lets see if verbose is useful

If it really is memory that is the problem, we are already using the max available resources. It is possible to work around by running only one config server in the auto testing, this will test 90% of the guide. We will see

... or @hmusum 