### PR TITLE
More mvn output

### DIFF
--- a/operations/album-recommendation-monitoring/album-recommendation-random-data/Dockerfile
+++ b/operations/album-recommendation-monitoring/album-recommendation-random-data/Dockerfile
@@ -3,7 +3,7 @@
 FROM maven:3.6.0-jdk-11 AS build
 COPY src /home/app/src
 COPY pom.xml /home/app
-RUN mvn -f /home/app/pom.xml --batch-mode -q clean package
+RUN mvn -f /home/app/pom.xml --batch-mode clean package
 
 FROM openjdk:11
 


### PR DESCRIPTION
Still get
````
Step 4/7 : RUN mvn -f /home/app/pom.xml --batch-mode -q clean package
 ---> Running in 93a7a623816a
unexpected EOF
sentinel-873624> exit code: 1
````
remove quiet option for now ... @lesters  it seems pexpect is timing out, default timeout is 30 minutes, https://cd.screwdriver.cd/pipelines/7021/builds/769378/steps/run-tests