### PR TITLE
Redundancy should be 2 MERGEOK

### DIFF
--- a/examples/http-api-using-request-handlers-and-processors/src/main/application/services.xml
+++ b/examples/http-api-using-request-handlers-and-processors/src/main/application/services.xml
@@ -33,7 +33,7 @@
         </nodes>
     </container>
     <content id="music" version="1.0">
-        <redundancy>1</redundancy>
+        <redundancy>2</redundancy>
         <documents>
             <document type="music" mode="index" />
         </documents>

--- a/examples/operations/basic-search-on-gke/templates/services.xml
+++ b/examples/operations/basic-search-on-gke/templates/services.xml
@@ -20,7 +20,7 @@ CONTAINER
   </container>
 
   <content id="music" version="1.0">
-    <redundancy>1</redundancy>
+    <redundancy>2</redundancy>
     <documents>
       <document type="music" mode="index" />
       <document-processing cluster="container"/>

--- a/model-evaluation/README.md
+++ b/model-evaluation/README.md
@@ -163,7 +163,7 @@ the model.
 
 **Test the document processor**
 
-Feed in a few documents by first downloading the `vespa-feed-client` Java client:
+Feed in a few documents by first downloading the [vespa-feed-client](https://docs.vespa.ai/en/vespa-feed-client.html): 
 
 <pre data-test="exec">
 $ curl -L -o vespa-feed-client-cli.zip \

--- a/model-evaluation/src/main/application/services.xml
+++ b/model-evaluation/src/main/application/services.xml
@@ -35,7 +35,7 @@
 
   <!-- Add a content cluster to searchers and document processors -->
   <content id="mycluster" version="1.0">
-    <redundancy>1</redundancy>
+    <redundancy>2</redundancy>
     <documents>
       <document type="mydoc" mode="index" />
     </documents>

--- a/msmarco-ranking/document-ranking.md
+++ b/msmarco-ranking/document-ranking.md
@@ -271,8 +271,6 @@ $ vespa test src/test/application/tests/system-test/passage-ranking-system-test.
 $ vespa test src/test/application/tests/system-test/document-ranking-system-test.json
 </pre>
 
-
-
 ## Feeding Sample Data
 Feed the sample documents using the [vespa-feed-client](https://docs.vespa.ai/en/vespa-feed-client.html).
 
@@ -347,7 +345,7 @@ $ ir_datasets export msmarco-document/train docs --format jsonl | \
 </pre>
 
 
-## Doc to query document expansion
+## Document to query document expansion
 For document expansion we use [docTTTTTquery](https://github.com/castorini/docTTTTTquery) 
 Follow the instructions at 
 [https://github.com/castorini/docTTTTTquery#per-document-expansion](https://github.com/castorini/docTTTTTquery#per-document-expansion),
@@ -378,11 +376,11 @@ Then run the script with --output_docs_path *doc_t5_query_updates.jsonl*.
 Place the output file *doc_t5_query_updates.json* in the directory of the sample app. ($SAMPLE_APP)
 
 <pre>
-$ vespa-feed-client --file all-feed.jsonl --endpoint http://localhost:8080
+$ ./vespa-feed-client-cli/vespa-feed-client --file all-feed.jsonl --endpoint http://localhost:8080
 </pre>
 
 <pre>
-$ vespa-feed-client --file doc_t5_query_updates.jsonl --endpoint http://localhost:8080
+$ ./vespa-feed-client-cli/vespa-feed-client --file doc_t5_query_updates.jsonl --endpoint http://localhost:8080
 </pre>
 
 

--- a/text-image-search/README.md
+++ b/text-image-search/README.md
@@ -100,7 +100,7 @@ $ vespa test src/test/application/tests/system-test/image-search-system-test.jso
 
 **Download and extract image data:**
 
-<pre data-test="exec">
+<pre>
 $ ./src/sh/download_flickr8k.sh
 $ export IMG_DIR=data/Flicker8k_Dataset/
 </pre>
@@ -112,11 +112,12 @@ uses [PyVespa](https://github.com/vespa-engine/pyvespa/) to feed the image data 
 This step take some time as each image is encoded using the CLIP model.
 Alternatively use pre-computed embeddings, see next instruction.
 
-<pre data-test="exec">
+<pre>
 $ python3 src/python/clip_feed.py
 </pre>
 
-Alternatively use pre-computed embeddings and feed directly with vespa-feed-client: 
+Alternatively, instead of computing the embeddings, use our pre-computed embeddings and feed directly with 
+[vespa-feed-client](https://docs.vespa.ai/en/vespa-feed-client.html): 
 
 <pre data-test="exec">
 $ curl -L -o vespa-feed-client-cli.zip \

--- a/text-image-search/src/main/application/services.xml
+++ b/text-image-search/src/main/application/services.xml
@@ -30,7 +30,7 @@
 
   <!-- Add a content cluster to searchers and document processors -->
   <content id="mycluster" version="1.0">
-    <redundancy>1</redundancy>
+    <redundancy>2</redundancy>
     <documents>
       <document type="image_search" mode="index" />
     </documents>


### PR DESCRIPTION
- Change redundancy to 2
- Disable computing of image embeddings per test run for now, to reduce turnaround time on testing

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
