### PR TITLE
Add nbmake and pytest for testing of Notebooks

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -73,6 +73,7 @@ jobs:
           apt update
           apt install -y docker.io zstd maven zip unzip python3-pip net-tools bundler
           python3 -m pip install -qqq -r test/requirements.txt --user
+          python3 -m pip install -qqq pytest nbmake --user
           VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")') && \
             curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
             ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/
@@ -101,6 +102,7 @@ jobs:
           apt update
           apt install -y docker.io zstd maven zip unzip python3-pip net-tools bundler
           python3 -m pip install -qqq -r test/requirements.txt --user
+          python3 -m pip install -qqq pytest nbmake --user
           VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")') && \
             curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
             ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/


### PR DESCRIPTION
This can allow us to add tests for notebooks that are part of sample apps, especially for pyvespa. It steps through all steps in the notebook, so we know if something broke. I'm uncertain yet how you add actual test for output etc, but this will be a good start :)

```
pytest --nbmake msmarco-ranking/src/main/python/model-exporting.ipynb 
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/bergum/cloud-ultimate/sample-apps/msmarco-ranking/src/main/python
plugins: anyio-2.2.0, nbmake-1.3.0
collected 1 item                                                                                                                                                          

model-exporting.ipynb 
.                                                                                                                                             [100%]

=========================================================================== 1 passed in 44.94s ============================================================================
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
