### PR TITLE
Update services.xml

### DIFF
--- a/examples/operations/multinode-HA/src/main/application/services.xml
+++ b/examples/operations/multinode-HA/src/main/application/services.xml
@@ -24,7 +24,7 @@
 
     <container id="feed" version="1.0">
         <document-api/>
-        <search/>
+        <document-processing/>
         <nodes>
             <jvm options="-Xms32M -Xmx128M"/> <!-- Added only to shrink memory for testing - remove before real use -->
             <node hostalias="node4" />
@@ -45,6 +45,7 @@
         <redundancy>2</redundancy>
         <documents>
             <document type="music" mode="index" />
+            <document-processing cluster="feed" />            
         </documents>
         <nodes>
             <node hostalias="node8" distribution-key="0" />

--- a/examples/operations/multinode-HA/src/main/application/services.xml
+++ b/examples/operations/multinode-HA/src/main/application/services.xml
@@ -24,6 +24,7 @@
 
     <container id="feed" version="1.0">
         <document-api/>
+        <search/>
         <nodes>
             <jvm options="-Xms32M -Xmx128M"/> <!-- Added only to shrink memory for testing - remove before real use -->
             <node hostalias="node4" />


### PR DESCRIPTION
Add `<search/>` to the feed container nodes.

Otherwise the index requests will end up in your query nodes. 
Not sure on why this happens. I just noticed that if I add `<search>` to the feed container then the cluster behaves as I expect, and does not use the query nodes while indexing.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
