### PR TITLE
Revert "Set release 17 MERGEOK"

### DIFF
--- a/examples/generic-request-processing/pom.xml
+++ b/examples/generic-request-processing/pom.xml
@@ -48,7 +48,7 @@
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <release>17</release>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/http-api-using-request-handlers-and-processors/pom.xml
+++ b/examples/http-api-using-request-handlers-and-processors/pom.xml
@@ -48,7 +48,7 @@
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <release>17</release>
+                    <release>11</release>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Werror</arg>

--- a/examples/operations/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
+++ b/examples/operations/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
@@ -45,7 +45,7 @@
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <release>17</release>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/predicate-fields/pom.xml
+++ b/examples/predicate-fields/pom.xml
@@ -45,7 +45,7 @@
                     <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
-                    <release>17</release>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Reverts vespa-engine/sample-apps#984

Cannot build using 17 and deploy into the current vespa7-in-11 containers:

````
[2022-06-09 11:38:43.664] ERROR   : container        Container.com.yahoo.jdisc.core.StandaloneMain	JDisc exiting: Throwable caught: \nexception=\njava.lang.UnsupportedClassVersionError: com/yahoo/example/SubqueriesSearcher has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0 ...
````

fyi @bratseth 