### PR TITLE
Try to fix test infra after upgrading opset version for transformer exports 

### DIFF
--- a/msmarco-ranking/src/main/python/model-exporting.ipynb
+++ b/msmarco-ranking/src/main/python/model-exporting.ipynb
@@ -157,7 +157,7 @@
     "                    \"attention_mask\": {0: \"batch\", 1: \"batch\"},\n",
     "                    \"contextual\": {0: \"batch\"},\n",
     "                },\n",
-    "                opset_version=15)"
+    "                opset_version=12)"
    ]
   },
   {
@@ -264,7 +264,7 @@
     "                    \"attention_mask\": {0: \"batch\", 1: \"batch\"},\n",
     "                    \"contextual\": {0: \"batch\", 1: \"batch\"},\n",
     "                },\n",
-    "                opset_version=15)"
+    "                opset_version=12)"
    ]
   },
   {
@@ -424,7 +424,7 @@
     "model = AutoModelForSequenceClassification.from_pretrained(cross_model)\n",
     "model = model.eval()\n",
     "pipeline = transformers.pipeline(\"text-classification\", model=model, tokenizer=tokenizer)\n",
-    "onnx_convert.convert_pytorch(pipeline, opset=15, output=Path(output_file), use_external_format=False)\n",
+    "onnx_convert.convert_pytorch(pipeline, opset=12, output=Path(output_file), use_external_format=False)\n",
     "onnx_convert.quantize(Path(output_file))"
    ]
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,7 +12,8 @@ shared:
         dnf -y install docker-ce protobuf-compiler protobuf-devel --nobest
         python3 -m pip install --upgrade pip
         python3 -m pip install -qqq -r test/requirements.txt --user
-        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch numpy transformers --user
+        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch==1.12.1 numpy transformers 
+        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch==1.12.1 numpy transformers --user
         VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")') && \
           curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,8 +12,8 @@ shared:
         dnf -y install docker-ce protobuf-compiler protobuf-devel --nobest
         python3 -m pip install --upgrade pip
         python3 -m pip install -qqq -r test/requirements.txt --user
-        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch==1.12.1 numpy transformers 
-        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch==1.12.1 numpy transformers --user
+        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch numpy transformers 
+        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch numpy transformers --user
         VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")') && \
           curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,8 +12,7 @@ shared:
         dnf -y install docker-ce protobuf-compiler protobuf-devel --nobest
         python3 -m pip install --upgrade pip
         python3 -m pip install -qqq -r test/requirements.txt --user
-        python3 -m pip install -qqq pytest nbmake onnx onnxruntime torch numpy transformers --user
-        python3 -m pip install --upgrade pytest nbmake onnx onnxruntime torch numpy transformers
+        python3 -m pip install --upgrade -qqq pytest nbmake onnx onnxruntime torch numpy transformers --user
         VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")') && \
           curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt && \
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/


### PR DESCRIPTION
```
ValueError: Unsupported ONNX opset version: 15
21:58:11 =============================== warnings summary ===============================
21:58:11 ../../../../../usr/local/lib/python3.6/site-packages/_pytest/nodes.py:140
21:58:11   /usr/local/lib/python3.6/site-packages/_pytest/nodes.py:140: PytestRemovedIn8Warning: The (fspath: py.path.local) argument to NotebookFile is deprecated. Please use the (path: pathlib.Path) argument instead.
21:58:11   See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
21:58:11     return super().__call__(*k, **kw)
21:58:11 
21:58:11 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
21:58:11 =========================== short test summary info ============================
21:58:11 FAILED src/main/python/model-exporting.ipynb:: - ValueError: Unsupported ONNX opset version: 15
21:58:11 ========================= 1 failed, 1 warning in 7.78s =========================
```


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
