### PR TITLE
Add testing to new sample app

### DIFF
--- a/simple-semantic-search/README.md
+++ b/simple-semantic-search/README.md
@@ -8,7 +8,10 @@ A minimal semantic search application:
 - Query and document text is converted to embeddings by the application. 
 - Search by embedding and/or text match.
 
+<p data-test="run-macro init-deploy simple-semantic-search">
 Requires at least Vespa 8.54.61.
+</p>
+
 
 ## To try this
 
@@ -17,20 +20,26 @@ Follow
 through the <code>vespa deploy</code> step, cloning simple-semantic-search instead of album-recommendation.
 
 Feed documents:
-<pre>
+<pre data-test="exec">
 vespa document ext/1.json
 vespa document ext/2.json
 vespa document ext/3.json
 </pre>
 
 Example queries:
-<pre>
+<pre data-test="exec" data-test-assert-contains="id:doc:doc::1">
 vespa query "yql=select * from doc where {targetHits: 100}nearestNeighbor(embedding, e)" "input.query(e)=embed(space contains many suns)"
 vespa query "yql=select * from doc where {targetHits: 100}nearestNeighbor(embedding, e)" "input.query(e)=embed(shipping stuff over the sea)"
 vespa query "yql=select * from doc where {targetHits: 100}nearestNeighbor(embedding, e)" "input.query(e)=embed(exchanging information by sound)"
 vespa query "yql=select * from doc where text contains 'boat'"
 vespa query "yql=select * from doc where {targetHits: 100}nearestNeighbor(embedding, e) AND text contains 'boat'" "input.query(e)=embed(exchanging information by sound)"
 </pre>
+
+Remove the container after use:
+<pre data-test="exec">
+$ docker rm -f vespa
+</pre>
+
 
 ## Ready for production
 


### PR DESCRIPTION
- Test script changes:
  - Also check for test attributes on &lt;p&gt; - there is always something visible one can attach test commands to
  - support a "macro" - predefined steps, like docker start + deploy. Can then use this more places to invoke common / shared steps

note: need the remove container step for the full test script run, where all files are tested in sequence. This is also helpful for the user, it is a common use case to rerun