### PR TITLE
Revert "Bump torch from 1.7.1 to 1.13.1 in /dense-passage-retrieval-with-ann"

### DIFF
--- a/dense-passage-retrieval-with-ann/requirements.txt
+++ b/dense-passage-retrieval-with-ann/requirements.txt
@@ -1,5 +1,5 @@
 protobuf >= 3.12.2, <= 3.20.1
-torch==1.13.1
+torch==1.7.1
 transformers==4.10.3
 onnx
 onnxruntime


### PR DESCRIPTION
Reverts vespa-engine/sample-apps#1114

failed with
```
ERROR: Could not find a version that satisfies the requirement torch==1.13.1 (from versions: 1.0.0, 1.0.1, 1.0.1.post2, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.4.0, 1.5.0, 1.5.1, 1.6.0, 1.7.0, 1.7.1, 1.8.0, 1.8.1, 1.9.0, 1.9.1, 1.10.0, 1.10.1, 1.10.2)
03:58:16 ERROR: No matching distribution found for torch==1.13.1
```