### PR TITLE
do not use torch 2.* (yet)

### DIFF
--- a/text-image-search/src/python/requirements.txt
+++ b/text-image-search/src/python/requirements.txt
@@ -1,4 +1,6 @@
-torch
+# torch 2.0 has an ONNX opset mismatch with the current code, use 1 until fixed. ToDo
+torch == 1.*
+
 torchvision
 ftfy
 regex


### PR DESCRIPTION
with 2.0 we get the below - lock version for now

````
# python3 src/python/clip_export.py
============= Diagnostic Run torch.onnx.export version 2.0.0+cu117 =============
verbose: False, log level: Level.ERROR
======================= 0 NONE 0 NOTE 0 WARNING 1 ERROR ========================
ERROR: missing-standard-symbolic-function
=========================================
Exporting the operator 'aten::unflatten' to ONNX opset version 14 is not supported. Please feel free to request support or submit a pull request on PyTorch GitHub: https://github.com/pytorch/pytorch/issues.
````
