### PR TITLE
Fix cloud deployment instructions

### DIFF
--- a/billion-scale-image-search/README.md
+++ b/billion-scale-image-search/README.md
@@ -14,7 +14,7 @@ cost-efficient large scale image search over multimodal AI powered vector repres
 This sample app use the [LAION-5B](https://laion.ai/blog/laion-5b/) dataset,
  the biggest open accessible image-text dataset in the world.
 
->Large image-text models like ALIGN, BASIC, Turing Bletchly, FLORENCE & GLIDE have 
+> Large image-text models like ALIGN, BASIC, Turing Bletchly, FLORENCE & GLIDE have
 > shown better and better performance compared to previous flagship models like CLIP and DALL-E.
 > Most of them had been trained on billions of image-text pairs and unfortunately, no datasets of this size had been openly available until now. 
 > To address this problem we present LAION 5B, a large-scale dataset for research purposes 
@@ -26,8 +26,8 @@ generative [StableDiffusion](https://stability.ai/blog/stable-diffusion-public-r
 
 Note the following about the LAION 5B dataset
 
->Be aware that this large-scale dataset is un-curated. 
-> Keep in mind that the un-curated nature of the dataset means that collected 
+> Be aware that this large-scale dataset is un-curated.
+> Keep in mind that the un-curated nature of the dataset means that collected
 > links may lead to strongly discomforting and disturbing content for a human viewer.
 
 The released dataset does not contain image data itself,
@@ -86,6 +86,7 @@ accelerated by stateless model inference.
 - Scale, from a single node deployment to multi-node deployment using managed [Vespa Cloud](https://cloud.vespa.ai/), 
 or self-hosted on-premise. 
 
+
 ## Stateless Components 
 The app contains several [container components](https://docs.vespa.ai/en/jdisc/container-components.html):
 
@@ -107,10 +108,11 @@ for playing around with the app on a laptop.
 * [Docker](https://www.docker.com/) Desktop installed and running. 6GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * [Java 17](https://openjdk.org/projects/jdk/17/) installed.
 * Python3 and numpy to process the vector dataset 
 * [Apache Maven](https://maven.apache.org/install.html) - this sample app uses custom Java components and Maven is used
@@ -123,41 +125,19 @@ $ docker info | grep "Total Memory"
 </pre>
 
 Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
-
-<pre >
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy this app to [Vespa Cloud](https://cloud.vespa.ai/)
-using target `cloud`. For Vespa cloud deployments to [perf env](https://cloud.vespa.ai/en/reference/zones.html) 
-replace the [src/main/application/services.xml](src/main/application/services.xml) with 
-[src/main/application/services-cloud.xml](src/main/application/services-cloud.xml). 
-
-For local deployment using docker image use:
-
+For local deployment using docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use:
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
-For an optimal deployment in Vespa Cloud, replace the `src/main/application/services.xml` with 
-`src/main/application/services-cloud.xml`. The cloud deployment uses
-dedicated clusters for `feed` and `query`. 
-See also [Cloud Vespa getting started guide](https://cloud.vespa.ai/en/getting-started). 
-
-For multi-node onpremise deployments, use
-the [multi-node high availability](https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA)
-template for inspiration. 
+Use the [multi-node high availability](https://github.com/vespa-engine/sample-apps/tree/master/examples/operations/multinode-HA)
+template for inspiration for multi-node, on-premise deployments.
 
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -166,13 +146,11 @@ $ docker run --detach --name vespa --hostname vespa-container \
 </pre>
 
 Verify that the configuration service (deploy api) is ready:
-
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
 Download this sample application:
-
 <pre data-test="exec">
 $ vespa clone billion-scale-image-search myapp && cd myapp
 </pre>
@@ -202,8 +180,8 @@ $ python3 -m pip install pandas numpy requests mmh3 pyarrow
 </pre>
 
 Generate centroids, this process randomly selects vectors from the dataset to represent
-centroids. Performing an incremental clustering can improve vector search recall and allow to
-index fewer centroids. For simplicity, this tutorial uses random sampling. 
+centroids. Performing an incremental clustering can improve vector search recall and allow
+indexing fewer centroids. For simplicity, this tutorial uses random sampling. 
 
 <pre data-test="exec">
 $ python3 src/main/python/create-centroid-feed.py img_emb_0000.npy > centroids.jsonl
@@ -219,9 +197,10 @@ $ python3 src/main/python/create-joined-feed.py metadata_0000.parquet img_emb_00
 To process the entire dataset, we recommend starting several processes, each operating on separate split files 
 as the processing implementation is single-threaded. 
 
+
 ## Build and deploy Vespa app 
 
-The models directory in the application package contains three small ONNX models:
+The [models](src/main/application/models) directory in the application package contains three small ONNX models:
 
 - `vespa_innerproduct_ranker.onnx` for vector similarity (inner dot product) between the query and the vectors
 in the stateless container.
@@ -247,6 +226,14 @@ Deploy the application. This step deploys the application package built in the p
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa deploy --wait 300
 </pre>
+
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started-java#deploy-sample-applications-java).
+For Vespa cloud deployments to [perf env](https://cloud.vespa.ai/en/reference/zones.html)
+replace the [src/main/application/services.xml](src/main/application/services.xml) with
+[src/main/application/services-cloud.xml](src/main/application/services-cloud.xml) -
+the cloud deployment uses dedicated clusters for `feed` and `query`.
 
 Wait for the application endpoint to become available:
 
@@ -342,7 +329,7 @@ The `text` [rank](https://docs.vespa.ai/en/ranking.html) profile uses
 [nativeRank](https://docs.vespa.ai/en/nativerank.html), one of Vespa's many 
 text matching rank features. 
 
-## Non-native hyper-parameters
+## Non-native hyperparameters
 There are several non-native query request 
 parameters that controls the vector search accuracy and performance tradeoffs. These
 can be set with the request, e.g, `/search/&spann.clusters=12`. 
@@ -353,7 +340,7 @@ A higher number improves recall, but increases computational complexity and disk
 A higher number improves recall, but increases the computational complexity and network. 
 - `collapse.enable`, default `true`, controls de-duping of the top ranked results using image to image similarity.
 - `collapse.similarity.max-hits`, default `1000`, the number of top-ranked hits to perform de-duping of. Must be less than `rank-count`.
-- `collapse.similarity.threshold`, default `0.95`, how similar an given image to image must be before it is considered a duplicate.
+- `collapse.similarity.threshold`, default `0.95`, how similar a given image to image must be before it is considered a duplicate.
 
 ## Areas of improvement 
 There are several areas that could be improved. 

--- a/billion-scale-vector-search/README.md
+++ b/billion-scale-vector-search/README.md
@@ -24,47 +24,30 @@ for reproducing on a laptop.
 * [Docker](https://www.docker.com/) Desktop installed and running. 6GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64 
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * [Java 17](https://openjdk.org/projects/jdk/17/) installed.
 * Python3 and numpy to process the vector dataset 
 * [Apache Maven](https://maven.apache.org/install.html) - this sample app uses custom Java components and Maven is used
   to build the application. 
 
 Verify Docker Memory Limits:
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
 Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
-
-<pre >
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy this app to [Vespa Cloud](https://cloud.vespa.ai/)
-using target cloud. For Vespa cloud deployments to [perf env](https://cloud.vespa.ai/en/reference/zones.html) 
-replace the [src/main/application/services.xml](src/main/application/services.xml) with 
-[src/main/application/cloud-services.xml](src/main/application/cloud-services.xml). 
-
 For local deployment using docker image use:
-
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
-
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use:
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login
-$ vespa auth cert
-</pre>
-
-See also [Cloud Vespa getting started guide](https://cloud.vespa.ai/en/getting-started). 
 
 <pre data-test="exec">
 $ git clone --depth 1 https://github.com/vespa-engine/sample-apps.git
@@ -72,7 +55,6 @@ $ cd sample-apps/billion-scale-vector-search
 </pre>
 
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -81,13 +63,11 @@ $ docker run --detach --name vespa --hostname vespa-container \
 </pre>
 
 Verify that the configuration service (deploy api) is ready:
-
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
 Download this sample application:
-
 <pre>
 $ vespa clone billion-scale-vector-search myapp && cd myapp
 </pre>
@@ -96,10 +76,8 @@ $ vespa clone billion-scale-vector-search myapp && cd myapp
 ## Download Vector Data
 This sample app uses the Microsoft SPACEV vector dataset from 
 [https://big-ann-benchmarks.com/](https://big-ann-benchmarks.com/).
-
 It uses the first 10M vectors of the 100M slice sample.
 This sample file is about 1GB (10M vectors):
-
 <pre data-test="exec">
 $ curl -L -o spacev10m_base.i8bin \
   https://data.vespa.oath.cloud/sample-apps-data/spacev10m_base.i8bin
@@ -111,12 +89,10 @@ This step creates two feed files:
 * `graph-vectors.jsonl`
 * `if-vectors.jsonl`
 
-Install python dependencies:
-
+Install dependencies and create the feed data:
 <pre data-test="exec">
 $ pip3 install numpy requests tqdm
 </pre>
-
 <pre data-test="exec">
 $ python3 src/main/python/create-vespa-feed.py spacev10m_base.i8bin
 </pre>
@@ -124,31 +100,30 @@ $ python3 src/main/python/create-vespa-feed.py spacev10m_base.i8bin
 
 ## Build and deploy Vespa app 
 Build the sample app:
-
 <pre data-test="exec" data-test-expect="BUILD SUCCESS" data-test-timeout="300">
 $ mvn clean package -U
 </pre>
 
 Deploy the application. This step deploys the application package built in the previous step:
-
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa deploy --wait 300
 </pre>
 
-Wait for the application endpoint to become available:
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started-java#deploy-sample-applications-java).
 
+Wait for the application endpoint to become available:
 <pre data-test="exec">
 $ vespa status --wait 300
 </pre>
 
 Test basic functionality:
-
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa test src/test/application/tests/system-test/feed-and-search-test.json
 </pre>
 
 The _graph_ vectors must be feed before the _if_ vectors:
-
 <pre data-test="exec">
 $ vespa feed graph-vectors.jsonl
 $ vespa feed if-vectors.jsonl
@@ -165,7 +140,6 @@ $ curl -L -o spacev10m_gt100.i8bin \
 </pre>
 
 Run first 1K queries and evaluate recall@10. Higher number of clusters gives higher recall:
-
 <pre data-test="exec">
 $ python3 src/main/python/recall.py --endpoint http://localhost:8080/search/ \
   --query_file query.i8bin \
@@ -174,7 +148,6 @@ $ python3 src/main/python/recall.py --endpoint http://localhost:8080/search/ \
 
 To evaluate recall using a deployment in Vespa Cloud perf zone the data plane certificate
 and key needs to be provided:
-
 <pre>
 $ python3 src/main/python/recall.py --endpoint https://app.tenant.aws-us-east-1c.perf.z.vespa-app.cloud/search/ \
   --query_file query.i8bin --query_gt_file GT_10M/msspacev-10M \

--- a/commerce-product-ranking/README.md
+++ b/commerce-product-ranking/README.md
@@ -1,4 +1,3 @@
-
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.-->
 
 ![Vespa logo](https://vespa.ai/assets/vespa-logo-color.png)
@@ -24,7 +23,13 @@ This post demonstrates how to train GBDT methods for search ranking. The model u
 
 This work uses the largest product relevance dataset released by Amazon:
 
->We introduce the “Shopping Queries Data Set”, a large dataset of difficult search queries, released with the aim of fostering research in the area of semantic matching of queries and products. For each query, the dataset provides a list of up to 40 potentially relevant results, together with ESCI relevance judgements (Exact, Substitute, Complement, Irrelevant) indicating the relevance of the product to the query. Each query-product pair is accompanied by additional information. The dataset is multilingual, as it contains queries in English, Japanese, and Spanish.
+> We introduce the “Shopping Queries Data Set”, a large dataset of difficult search queries,
+> released with the aim of fostering research in the area of semantic matching of queries and products.
+> For each query, the dataset provides a list of up to 40 potentially relevant results,
+> together with ESCI relevance judgements (Exact, Substitute, Complement, Irrelevant)
+> indicating the relevance of the product to the query.
+> Each query-product pair is accompanied by additional information.
+> The dataset is multilingual, as it contains queries in English, Japanese, and Spanish.
 
 The dataset is found at [amazon-science/esci-data](https://github.com/amazon-science/esci-data). 
 The dataset is released under the [Apache 2.0 license](https://github.com/amazon-science/esci-data/blob/main/LICENSE).
@@ -36,6 +41,7 @@ The following is a quick start recipe on how to get started with this applicatio
 * [Docker](https://www.docker.com/) Desktop installed and running. 6 GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download 
@@ -44,40 +50,21 @@ The following is a quick start recipe on how to get started with this applicatio
 * Python3 with `requests` `pyarrow` and `pandas` installed 
 
 Validate Docker resource settings, should be minimum 6 GB:
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html). 
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy this application to [Vespa Cloud](https://cloud.vespa.ai/)
-using target cloud. 
-
-For local deployment using docker image use 
-
+For local deployment using docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use
-
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
-See also [Cloud Vespa getting started guide](https://cloud.vespa.ai/en/getting-started). It's possible
-to switch between local deployment and cloud deployment by changing the `config target`. 
-
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -85,21 +72,18 @@ $ docker run --detach --name vespa --hostname vespa-container \
   vespaengine/vespa
 </pre>
 
-Verify that configuration service (deploy api) is ready
-
+Verify that configuration service (deploy api) is ready:
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
-Download this sample application 
-
+Download this sample application:
 <pre data-test="exec">
 $ vespa clone commerce-product-ranking my-app && cd my-app
 </pre>
 
 Download ONNX models for neural ranking:
-
-<pre data-test="exec"> 
+<pre data-test="exec">
 $ mkdir -p application/models
 $ curl -L -o application/models/title_ranker.onnx \
     https://data.vespa.oath.cloud/sample-apps-data/title_ranker.onnx
@@ -115,11 +99,15 @@ See [scripts/export-bi-encoder.py](scripts/export-bi-encoder.py) and
 [scripts/export-cross-encoder.py](scripts/export-cross-encoder.py) for how
 to export models from PyTorch to ONNX format. 
 
-Deploy the application : 
-
+Deploy the application:
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa deploy --wait 300 application
 </pre>
+
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started#deploy-sample-applications).
+
 
 ## Run basic system test
 
@@ -130,6 +118,7 @@ documents and runs a query [test](https://docs.vespa.ai/en/reference/testing.htm
 $ (cd application; vespa test tests/system-test/feed-and-search-test.json)
 </pre>
 
+
 ## Indexing sample product data
 
 Download the pre-processed sample product data for 16 products:
@@ -137,6 +126,7 @@ Download the pre-processed sample product data for 16 products:
 <pre data-test="exec">
 $ zstdcat sample-data/sample-products.jsonl.zstd | vespa feed -
 </pre>
+
 
 ## Evaluation 
 
@@ -165,7 +155,6 @@ $ cat semantic-title.run
 </pre>
 
 Example ranking produced by Vespa using the `semantic-title` rank-profile for query 535:
-
 <pre>
 535 Q0 B08PB9TTKT 1 0.46388297538130346 semantic-title
 535 Q0 B00B4PJC9K 2 0.4314163871097326 semantic-title
@@ -185,12 +174,10 @@ Example ranking produced by Vespa using the `semantic-title` rank-profile for qu
 535 Q0 B0742BZXC2 16 0.3778094352830984 semantic-title
 </pre>
 
-This run file can then 
-be evaluated using the [trec_eval](https://github.com/usnistgov/trec_eval) utility.
+This run file can then be evaluated using the [trec_eval](https://github.com/usnistgov/trec_eval) utility.
 
 Download a pre-processed query-product relevance judgments in TREC format:
-
-<pre data-test="exec"> 
+<pre data-test="exec">
 $  curl -L -o test.qrels \
     https://data.vespa.oath.cloud/sample-apps-data/test.qrels
 </pre>
@@ -234,18 +221,19 @@ $ trec_eval test.qrels cross-title.run -m 'ndcg.1=0,2=0.01,3=0.1,4=1'
 
 Which for this query produces a NDCG score of 0.8208, better than the semantic-title model.
 
-## Shutdown and remove the Docker container
 
+## Shutdown and remove the Docker container
 
 <pre data-test="after">
 $ docker rm -f vespa
 </pre>
 
+
 ## Full evaluation 
 
 Download a pre-processed feed file with all (1,215,854) products:
 
-<pre> 
+<pre>
 $  curl -L -o product-search-products.jsonl.zstd \
     https://data.vespa.oath.cloud/sample-apps-data/product-search-products.jsonl.zstd
 </pre>
@@ -282,4 +270,3 @@ Run evaluation using `trec_eval`:
 <pre>
 $ trec_eval test.qrels semantic-title.run -m 'ndcg.1=0,2=0.01,3=0.1,4=1
 </pre>
-

--- a/custom-embeddings/README.md
+++ b/custom-embeddings/README.md
@@ -11,53 +11,35 @@ Frozen data embeddings from Foundational models are an emerging industry practic
 
 Read the [blog post](https://blog.vespa.ai/).
 
-## Quick start
 
-The following is a quick start recipe on how to get started with this application. 
+## Quick start
+The following is a quick start recipe on how to get started with this application:
 
 * [Docker](https://www.docker.com/) Desktop installed and running. 4 GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download 
   a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 
 Validate Docker resource settings, should be minimum 4 GB:
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html). 
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy this application to [Vespa Cloud](https://cloud.vespa.ai/)
-using target cloud. 
-
-For local deployment using docker image use 
-
+For local deployment using docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use
-
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
-See also [Cloud Vespa getting started guide](https://cloud.vespa.ai/en/getting-started). 
-It's possible to switch between local deployment and cloud deployment by changing the `config target`. 
-
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -65,42 +47,42 @@ $ docker run --detach --name vespa --hostname vespa-container \
   vespaengine/vespa
 </pre>
 
-Verify that configuration service (deploy api) is ready
-
+Verify that configuration service (deploy api) is ready:
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
-Download this sample application 
-
+Download this sample application:
 <pre data-test="exec">
 $ vespa clone custom-embeddings my-app && cd my-app
 </pre>
 
 Download a frozen embedding model file, see 
-[text embeddings made easy](https://blog.vespa.ai/text-embedding-made-simple/) for details.
-
-<pre data-test="exec"> 
+[text embeddings made easy](https://blog.vespa.ai/text-embedding-made-simple/) for details:
+<pre data-test="exec">
 $ mkdir -p models
 $ curl -L -o models/bert-base-uncased.txt \
-    https://raw.githubusercontent.com/vespa-engine/sample-apps/master/simple-semantic-search/model/bert-base-uncased.txt
+  https://raw.githubusercontent.com/vespa-engine/sample-apps/master/simple-semantic-search/model/bert-base-uncased.txt
 
 $ curl -L -o models/frozen.onnx \
-    https://github.com/vespa-engine/sample-apps/raw/master/simple-semantic-search/model/minilm-l6-v2.onnx
+  https://github.com/vespa-engine/sample-apps/raw/master/simple-semantic-search/model/minilm-l6-v2.onnx
 
-$ cp models/frozen.onnx  models/tuned.onnx 
+$ cp models/frozen.onnx models/tuned.onnx 
 </pre>
 
 In this case, we re-use the frozen model as the tuned model to demonstrate functionality.
 
-Deploy the application : 
-
+Deploy the application :
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa deploy --wait 300
 </pre>
 
-## Indexing sample documents 
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started#deploy-sample-applications).
 
+
+## Indexing sample documents
 <pre data-test="exec">
 vespa document ext/1.json
 vespa document ext/2.json
@@ -112,7 +94,6 @@ vespa document ext/3.json
 We demonstrate using `vespa cli`, use `-v` to see the curl equivalent using HTTP api.  
 
 ### Simple retrieve all documents with undefined ranking:
-
 <pre data-test="exec" data-test-assert-contains='"totalCount": 3'>
 vespa query 'yql=select * from doc where true' \
 'ranking=unranked'
@@ -141,8 +122,7 @@ vespa query 'yql=select * from doc where {targetHits:10}nearestNeighbor(embeddin
 This invokes the `simple-similarity` ranking model, which performs the query transformation
 to the tuned embedding. 
 
-### Using the Deep Neural Network similarity 
-
+### Using the Deep Neural Network similarity
 <pre data-test="exec" data-test-assert-contains='"totalCount": 3'>
 vespa query 'yql=select * from doc where {targetHits:10}nearestNeighbor(embedding, q)' \
 'input.query(q)=embed(tuned, "space contains many suns")' \
@@ -162,6 +142,7 @@ vespa visit --field-set "[all]" > ../vector-data.jsonl
 <pre>
 curl "http://localhost:8080/document/v1/doc/doc/docid/1?fieldSet=\[all\]"
 </pre>
+
 
 ## Cleanup
 Tear down the running container:

--- a/dense-passage-retrieval-with-ann/README.md
+++ b/dense-passage-retrieval-with-ann/README.md
@@ -38,6 +38,7 @@ Requirements:
 * [Docker](https://www.docker.com/) Desktop installed and running. 6GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64 
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
@@ -51,40 +52,21 @@ Requirements:
 See also [Vespa quick start guide](https://docs.vespa.ai/en/vespa-quick-start.html).
 
 Validate Docker resource settings, should be minimum 6GB:
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy to [Vespa Cloud](https://cloud.vespa.ai/)
-using target cloud.
-
-For local deployment using docker image use
-
+For local deployment using docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use
-
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
-See also [Cloud Vespa getting started guide](https://cloud.vespa.ai/en/getting-started). It's possible
-to switch between local deployment and cloud deployment by changing the `config target`.
-
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -92,22 +74,19 @@ $ docker run --detach --name vespa --hostname vespa-container \
   vespaengine/vespa
 </pre>
 
-Verify that configuration service (deploy api) is ready
-
+Verify that configuration service (deploy api) is ready:
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
-Download this sample application
-
+Download this sample application:
 <pre data-test="exec">
 $ vespa clone dense-passage-retrieval-with-ann myapp && cd myapp
 </pre>
 
-
 Download and set up the Transformer models, and build the application package.
-This can take some time as the two BERT-based models are around 100Mb each. The quick
-start uses quantized model versions. 
+This can take some time as the two BERT-based models are around 100Mb each.
+The quick start uses quantized model versions. 
 
 <pre data-test="exec">
 $ pip3 install -r requirements.txt
@@ -118,7 +97,7 @@ $ python3 bin/export-query-model.py src/main/application/models/question_encoder
 $ mv src/main/application/models/question_encoder-quantized.onnx src/main/application/models/question_encoder.onnx
 </pre>
 
-Build the application package 
+Build the application package:
 <pre data-test="exec" data-test-expect="BUILD SUCCESS" data-test-timeout="300">
 $ mvn clean package -U
 </pre>
@@ -128,39 +107,37 @@ Deploy the application package:
 $ vespa deploy --wait 300
 </pre>
 
-Wait for the application endpoint to become available
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started#deploy-sample-applications).
 
+Wait for the application endpoint to become available:
 <pre data-test="exec">
 $ vespa status --wait 300
 </pre>
 
 Running [Vespa System Tests](https://docs.vespa.ai/en/reference/testing.html)
-which runs a set of basic tests to verify that the application is working as expected.
-
+which runs a set of basic tests to verify that the application is working as expected:
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa test src/test/application/tests/system-test/passage-ranking-system-test.json
 </pre>
 
 Feed sample data:
-
 <pre data-test="exec">
 $ vespa feed sample-feed.jsonl
 </pre>
 
-Run a question: 
-
+Run a question:
 <pre data-test="exec" data-test-assert-contains='prediction": "2, 700"'>
 $ curl -s "http://localhost:8080/search/?query=what+is+the+population+of+achill+island%3F" | python3 -m json.tool
 </pre>
 
-Run another question: 
-
+Run another question:
 <pre data-test="exec" data-test-assert-contains='prediction": "78. 29'>
 $ curl -s "http://localhost:8080/search/?query=what+is+the+boiling+point+of+ethanol%3F" | python3 -m json.tool
 </pre>
 
 After you are done, shutdown and remove the container:
-
 <pre data-test="after">
 $ docker rm -f vespa
 </pre>
@@ -194,7 +171,6 @@ Note that the data is large, the text passage representation
 
 To download the pre-generated Wikipedia snippets and the pre-computed passage
 embeddings use the DPR download utility:
-
 <pre>
 $ python3 dpr/data/download_data.py --resource data.wikipedia_split
 $ python3 dpr/data/download_data.py --resource data.retriever_results.nq.single.wikipedia_passages
@@ -202,15 +178,13 @@ $ python3 dpr/data/download_data.py --resource data.retriever_results.nq.single.
 
 To generate the combined feed file use the *make-vespa-feed.py* script.  
 It reads the entire Wikipedia passage text dataset into memory, reads one embedding file at a time
-and emits a joint Vespa document representation of the textual passage data with the precomputed DPR passage embedding.
-
+and emits a joint Vespa document representation of the textual passage data with the precomputed DPR passage embedding:
 <pre>
 $ cd ..
 $ python3 bin/make-vespa-feed.py DPR/downloads/data/wikipedia_split/psgs_w100.tsv DPR/downloads/data/retriever_results/nq/single/wikipedia_passages_*.pkl > feed.jsonl 
 </pre>
 
-The script generates the input feed file, sample snippet: 
-
+The script generates the input feed file, sample snippet:
 <pre>
 {
   "put": "id:wiki:wiki::41",
@@ -225,16 +199,15 @@ The script generates the input feed file, sample snippet:
 
 The final feed file is 273G uncompressed. Adding compression like zstd/zip is highly recommended. Feed the file using the 
 same tool as with the toy sample data:
-
 <pre>
 $ vespa feed feed.jsonl
 </pre>
+
 
 ## Experiments
 
 With the full dataset indexed in Vespa, on can run all questions from the
 Natural Questions (NQ) dev split using the three different retrieval strategies:
-
 <pre>
 $ curl -L -o NQ-open.dev.jsonl https://raw.githubusercontent.com/google-research-datasets/natural-questions/master/nq_open/NQ-open.dev.jsonl
 $ python3 bin/evaluate_em.py NQ-open.dev.jsonl dense http://your-vespa-instance-hostname:8080
@@ -247,8 +220,7 @@ $ python3 bin/evaluate_em.py NQ-open.dev.jsonl hybrid http://your-vespa-instance
 
 The following section describe the experiments performed with this setup,
 all experiments are done running queries using the [Vespa query api](https://docs.vespa.ai/en/query-api)
-and checking the predicted answer against the golden reference answer(s).
-
+and checking the predicted answer against the golden reference answer(s):
 <pre>
 def get_vespa_result(question, retriever_model):
   request_body = {
@@ -282,11 +254,11 @@ Three different retrieval strategies are evaluated:
 * **Hybrid** Using a linear combination of the above and using OR to combine
   the weakAnd and nearestNeighbor search operator.
 
-| Retrieval Model                 | Recall@1  | Recall@5 | Recall@10| Recall@20 |
-|-------------------------------- |-----------|----------|----------|-----------|
-| sparse (WAND bm25)              | 23.77     | 44.24    | 52.69    | 61.47     |
-| dense  (nearest neighbor)       | 46.37     | 68.53    | 75.07    | 80.36     |
-| hybrid (WAND + nearest neighbor)| 40.61     | 69.25    | 75.96    | 80.44     |
+| Retrieval Model                  | Recall@1 | Recall@5 | Recall@10 | Recall@20 |
+|----------------------------------|----------|----------|-----------|-----------|
+| sparse (WAND bm25)               | 23.77    | 44.24    | 52.69     | 61.47     |
+| dense  (nearest neighbor)        | 46.37    | 68.53    | 75.07     | 80.36     |
+| hybrid (WAND + nearest neighbor) | 40.61    | 69.25    | 75.96     | 80.44     |
 
 The DPR paper reports Recall@20 79.4,
 so results are in accordance with the reported results for the dense retrieval method.
@@ -305,21 +277,19 @@ it will not  match the golden answers which are *14 December 1972 UTC* or *Decem
 **Original Natural Question dev set**
 ([NQ-open.dev.jsonl](https://github.com/google-research-datasets/natural-questions/blob/master/nq_open/NQ-open.dev.jsonl))
 
-| Retrieval Model                 | EM(@5)    | EM (@10)|
-|---------------------------------|-----------|--------|
-| sparse (WAND bm25               | 23.80     | 26.23  |
-| dense  (nearest neighbor)       | 39.34     | 40.58  |
-| hybrid (WAND + nearest neighbor)| 39.36     | 40.61  |
+| Retrieval Model                  | EM(@5) | EM (@10) |
+|----------------------------------|--------|----------|
+| sparse (WAND bm25                | 23.80  | 26.23    |
+| dense  (nearest neighbor)        | 39.34  | 40.58    |
+| hybrid (WAND + nearest neighbor) | 39.36  | 40.61    |
 
 
-## Summary 
-
+## Summary
 <!--
 <figure>
 <p align="center"><img width="90%" src="img/embedding_learning.png" /></p>
 </figure>
 -->
-
 
 <img width="90%" src="img/two-towers-embedding.png" alt="DPR Two Tower Embedding Architecture" />
 
@@ -332,7 +302,6 @@ in the same Vespa [document schema](src/main/application/schemas/wiki.sd).
 We also store the token ids from the BERT tokenization as Vespa tensor fields.
 These token_ids fields are not used by the retriever component, but by the reader.
 The tensor field type in Vespa is always stored in memory for fast access during retrieval and ranking. Schema:
-
 <pre>
 schema wiki {
 
@@ -396,7 +365,7 @@ We enable [HNSW index for fast approximate nearest neighbor search](https://docs
 
 The dual query and document encoder of the DPR retrieval system uses the inner
 dot product between the query tensor and the document tensor to represent the score.
-Internally, Vespa transform the 768 dimensional inner product space to angular-distance space using a
+Internally, Vespa transforms the 768 dimensional inner product space to angular-distance space using a
 [transformation](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf) which adds one dimension.
 The DPR implementation uses the same space transformation when using
 [Faiss with HNSW index](https://github.com/facebookresearch/faiss).
@@ -469,7 +438,6 @@ The function builds a tensor: [[CLS, question_token_ids, SEP, title_token_ids, S
 which is evaluated by the Reader ONNX model.
 **summary-features** is a way to pass ranking features and tensors
 from the content nodes to the java serving container.
-
 
 <img width="90%" src="img/reader.png" alt="Model overview"/>
 

--- a/examples/part-purchases-demo/README.md
+++ b/examples/part-purchases-demo/README.md
@@ -19,7 +19,6 @@ A sample Vespa application to assist with learning how to group according to the
 
 
 **Validate environment, should be minimum 4G:**
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
@@ -29,7 +28,6 @@ for details and troubleshooting:
 
 
 **Check-out, start Docker container:**
-
 <pre data-test="exec">
 $ git clone --depth 1 https://github.com/vespa-engine/sample-apps.git
 $ cd sample-apps/examples/part-purchases-demo

--- a/examples/predicate-fields/README.md
+++ b/examples/predicate-fields/README.md
@@ -52,6 +52,7 @@ Requirements:
 * [Docker](https://www.docker.com/) Desktop installed and running. 6 GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
@@ -61,34 +62,21 @@ Requirements:
   This sample app uses custom Java components and Maven is used to build the application.
 
 Validate Docker resource settings, should be minimum 4 GB:
-
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
 Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
-
-<pre >
+<pre>
 $ brew install vespa-cli
 </pre>
 
-For local deployment using the docker image, use:
-
+For local deployment using the docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/), use:
-
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -97,28 +85,28 @@ $ docker run --detach --name vespa --hostname vespa-container \
 </pre>
 
 Verify that configuration service (deploy api) is ready:
-
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
 Download this sample application:
-
 <pre data-test="exec">
 $ vespa clone examples/predicate-fields my-app && cd my-app
 </pre>
 
 Build the sample app:
-
 <pre data-test="exec">
 $ mvn package -U
 </pre>
 
-Finally, deploy the app:
-
+Deploy the app:
 <pre data-test="exec">
 $ vespa deploy --wait 300
 </pre>
+
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started-java#deploy-sample-applications-java).
 
 
 ## Index marketplace users

--- a/incremental-search/search-suggestions/README.md
+++ b/incremental-search/search-suggestions/README.md
@@ -1,4 +1,3 @@
-
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 
 ![Vespa logo](https://vespa.ai/assets/vespa-logo-color.png)
@@ -13,6 +12,7 @@ and extracts terms and phrases.
 [Prefix match](https://docs.vespa.ai/en/text-matching-ranking.html#prefix-match) is used,
 so suggestions are shown as the user types.
 
+<!-- ToDo check this after deploying new suggestions script - we might need to kill this app and point to new code -->
 This sample application is also deployed for [vespa-documentation-search](https://github.com/vespa-cloud/vespa-documentation-search),
 see [schema](https://github.com/vespa-cloud/vespa-documentation-search/blob/main/src/main/application/schemas/term.sd).
 Note an enhancement to this sample app:
@@ -50,7 +50,8 @@ a real application could implement a more sophisticated ranking for better sugge
 ### Performance considerations
 For short inputs, a trick is to use range queries with 
 [hitLimit](https://docs.vespa.ai/en/reference/query-language-reference.html#hitlimit) on a fast-search attribute. 
-This changes the semantics of the prefix query to only match against documents in the top 1K, which is usually what one wants for short prefix lengths.
+This changes the semantics of the prefix query to only match against documents in the top 1K,
+which is usually what one wants for short prefix lengths.
 * [Advanced range search with hitLimit](https://docs.vespa.ai/en/performance/practical-search-performance-guide.html#advanced-range-search-with-hitlimit)
 
 ## Quick start
@@ -58,50 +59,31 @@ Requirements:
 * [Docker](https://www.docker.com/) Desktop installed and running. 4GB available memory for Docker is recommended.
   Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
   for details and troubleshooting
+* Alternatively, deploy using [Vespa Cloud](#deployment-note)
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64 
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * [Java 17](https://openjdk.org/projects/jdk/17/) installed.
 * [Apache Maven](https://maven.apache.org/install.html) This sample app uses custom Java components and Maven is used
   to build the application.
 
-**Validate environment, must be minimum 4GB:**
-
-Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
-for details and troubleshooting:
+Validate environment, must be minimum 4GB:
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 
-Set target env, it's also possible to deploy to [Vespa Cloud](https://cloud.vespa.ai/)
-using target cloud.
-
-For local deployment using docker image use
-
+For local deployment using docker image:
 <pre data-test="exec">
 $ vespa config set target local
 </pre>
 
-For cloud deployment using [Vespa Cloud](https://cloud.vespa.ai/) use
-
-<pre>
-$ vespa config set target cloud
-$ vespa config set application tenant-name.myapp.default
-$ vespa auth login 
-$ vespa auth cert
-</pre>
-
-Where tenant-name is the tenant created when signing up for cloud.
-
 Pull and start the vespa docker container image:
-
 <pre data-test="exec">
 $ docker pull vespaengine/vespa
 $ docker run --detach --name vespa --hostname vespa-container \
@@ -109,78 +91,74 @@ $ docker run --detach --name vespa --hostname vespa-container \
   vespaengine/vespa
 </pre>
 
-Download this sample application
+Download this sample application:
 <pre data-test="exec">
 $ vespa clone incremental-search/search-suggestions myapp && cd myapp
 </pre>
 
-Build the application package
+Build the application package:
 <pre data-test="exec" data-test-expect="BUILD SUCCESS" data-test-timeout="300">
 $ mvn clean package -U
 </pre>
 
-Verify that configuration service (deploy api) is ready
-
+Verify that configuration service (deploy api) is ready:
 <pre data-test="exec">
 $ vespa status deploy --wait 300
 </pre>
 
-Deploy the application
-
+Deploy the application:
 <pre data-test="exec" data-test-assert-contains="Success">
 $ vespa deploy --wait 300
 </pre>
 
-Wait for the application endpoint to become available
+#### Deployment note
+It is possible to deploy this app to
+[Vespa Cloud](https://cloud.vespa.ai/en/getting-started-java#deploy-sample-applications-java).
 
+Wait for the application endpoint to become available:
 <pre data-test="exec">
 $ vespa status --wait 300
 </pre>
 
-**Feed the example documents**
-Feed documents using the [vespa-cli](https://docs.vespa.ai/en/vespa-cli.html):
-
+Feed the example documents:
+<!-- ToDo rewrite to using vespa feed -->
 <pre data-test="exec">
 $ while read -r line; do echo $line > tmp.json; vespa document tmp.json; done < example_feed.jsonl
 </pre>
 
-**Check the website, write queries and view suggestions**
-
-Open http://localhost:8080/site/ in a browser.
-To validate the site is up:
+Check the website, write queries and view suggestions.
+Open http://localhost:8080/site/ in a browser:
 <pre data-test="exec" data-test-assert-contains="search suggestions">
 $ curl -s http://localhost:8080/site/
 </pre>
 
 
-**Do a prefix query**
-Using [YQL](https://docs.vespa.ai/en/query-language.html) using *contains* with prefix annotation:
+Do a prefix query -
+using [YQL](https://docs.vespa.ai/en/query-language.html) using *contains* with prefix annotation:
 <pre data-test="exec" data-test-assert-contains="id:term:term::streaming">
 $ vespa query 'yql=select documentid,term from sources term where term contains ([{"prefix":true}]"stre");'
 </pre>
 
-YQL with [userQuery()](https://docs.vespa.ai/en/reference/query-language-reference.html#userquery) and [simple query language](https://docs.vespa.ai/en/reference/simple-query-language-reference.html)
+YQL with [userQuery()](https://docs.vespa.ai/en/reference/query-language-reference.html#userquery) and
+[simple query language](https://docs.vespa.ai/en/reference/simple-query-language-reference.html):
 * Note: The `term` field is defined as a field in the default [fieldset](https://docs.vespa.ai/en/schemas.html#fieldset)
-
 <pre data-test="exec" data-test-assert-contains="id:term:term::streaming">
 vespa query 'yql=select documentid,term from sources term where userQuery()' 'query=str*'
 </pre>
 
-YQL with [userInput()](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput) and [simple query language](https://docs.vespa.ai/en/reference/simple-query-language-reference.html)
-
+YQL with [userInput()](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput) and
+[simple query language](https://docs.vespa.ai/en/reference/simple-query-language-reference.html):
 <pre data-test="exec" data-test-assert-contains="id:term:term::streaming">
 vespa query 'yql=select documentid,term from sources term where ([{"defaultIndex":"default"}]userInput(@query))' 'query=str*'
 </pre>
 * Note: with userInput, the `defaultIndex` has to be set, it can be a field, or a [fieldset](https://docs.vespa.ai/en/schemas.html#fieldset)
 
 Using regular expression [YQL](https://docs.vespa.ai/en/query-language.html) with *matches* instead of *contains*:
-
 <pre data-test="exec" data-test-assert-contains="id:term:term::streaming">
 $ vespa query 'yql=select documentid,term from sources term where term matches "stre"'
 </pre>
 
-**Shutdown and remove the docker container**
-
+Shutdown and remove the docker container:
 <pre data-test="after">
 $ docker rm -f vespa
 </pre>

--- a/msmarco-ranking/document-ranking-README.md
+++ b/msmarco-ranking/document-ranking-README.md
@@ -1,4 +1,3 @@
-
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.-->
 
 ![Vespa logo](https://vespa.ai/assets/vespa-logo-color.png)

--- a/text-image-search/README.md
+++ b/text-image-search/README.md
@@ -37,7 +37,7 @@ Requirements:
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64 
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * [Java 17](https://openjdk.org/projects/jdk/17/) installed.
 * [Apache Maven](https://maven.apache.org/install.html) This sample app uses custom Java components and Maven is used
   to build the application.
@@ -54,9 +54,8 @@ for details and troubleshooting:
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 

--- a/text-search/README.md
+++ b/text-search/README.md
@@ -23,10 +23,10 @@ The following is for deploying the end to end application including a custom fro
 * Architecture: x86_64 or arm64 
 * Minimum **10 GB** memory dedicated to Docker (the default is 2 GB on Macs)
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * python 3 
-* [Java 17](https://openjdk.org/projects/jdk/17/) installed.
-* [Apache Maven](https://maven.apache.org/install.html) Maven is used
+* [Java 17](https://openjdk.org/projects/jdk/17/)
+* [Apache Maven](https://maven.apache.org/install.html)
 
 ## Installing vespa-cli
 

--- a/transformers/README.md
+++ b/transformers/README.md
@@ -28,21 +28,16 @@ Vespa stateless container.
 * Operating system: Linux, macOS or Windows 10 Pro (Docker requirement)
 * Architecture: x86_64 or arm64 
 * [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or download
-  a vespa cli release from [Github releases](https://github.com/vespa-engine/vespa/releases).
+  a vespa cli release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
 * python3.8+ to export models from Huggingface. 
 
-**Validate environment, should be minimum 6G:**
-
-Refer to [Docker memory](https://docs.vespa.ai/en/operations/docker-containers.html#memory)
-for details and troubleshooting:
-
+Validate environment, should be minimum 6G:
 <pre>
 $ docker info | grep "Total Memory"
 </pre>
 
-Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html).
-
-<pre >
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
 $ brew install vespa-cli
 </pre>
 


### PR DESCRIPTION
- Primarily unifying the "deploy to cloud" section with a link
- typos and minor text fixes, too - guides are the same
- a few more files to go, next PR - this one in big enough
