### PR TITLE
Revert "Bump transformers from 4.10.3 to 4.30.0 in /dense-passage-retrieval-with-ann"

### DIFF
--- a/dense-passage-retrieval-with-ann/requirements.txt
+++ b/dense-passage-retrieval-with-ann/requirements.txt
@@ -1,5 +1,5 @@
 protobuf >= 3.12.2, <= 3.20.1
 torch==1.10.2
-transformers==4.30.0
+transformers==4.10.3
 onnx
 onnxruntime==1.9.0


### PR DESCRIPTION
- Reverts vespa-engine/sample-apps#1217
- build is broken, revert for now - this app will be rewritten