### PR TITLE
fix errors in vespa-chinese-linguistics

### DIFF
--- a/examples/vespa-chinese-linguistics/README.md
+++ b/examples/vespa-chinese-linguistics/README.md
@@ -44,7 +44,7 @@ For example, the structure will be like below with sampleapps.
 * sampleapps/search/kosmos/
     * services.xml
     * components/
-        * chinese-linguistics-1.0.0-deploy.jar
+        * vespa-chinese-linguistics-1.0.0-deploy.jar
 
 
 ### Configuration
@@ -54,15 +54,16 @@ it is recommended to define &lt;component&gt; in all &lt;container&gt; sections 
 
 ```xml
 <container id="mycontainer" version="1.0">
-    <component id="com.qihoo.language.JiebaLinguistics" bundle="chinese-linguistics" >
+    <component id="com.qihoo.language.JiebaLinguistics" bundle="vespa-chinese-linguistics" >
         <config name="com.qihoo.language.config.dicts-loc">
-            <dictionaryPath>/opt/vespa/conf/dict</dictionaryPath>
-            <stopwordsPath>/opt/vespa/conf/stopwords</stopwordsPath>
+            <dictionaryPath>/opt/vespa/conf/jieba</dictionaryPath>
+            <stopwordsPath>/opt/vespa/conf/jieba/stopwords</stopwordsPath>
         </config>
     </component>
 </container>
 ```
 
+User dict files should ends with `.dict`, such as `/opt/vespa/conf/jieba/user.dict`.
 
 ## License
 Code licensed under the Apache 2.0 license. See LICENSE for terms.

--- a/examples/vespa-chinese-linguistics/pom.xml
+++ b/examples/vespa-chinese-linguistics/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>linguistics</artifactId>
+      <artifactId>opennlp-linguistics</artifactId>
       <version>${vespa_version}</version>
       <scope>provided</scope>
     </dependency>

--- a/examples/vespa-chinese-linguistics/src/main/java/com/qihoo/language/JiebaLinguistics.java
+++ b/examples/vespa-chinese-linguistics/src/main/java/com/qihoo/language/JiebaLinguistics.java
@@ -8,72 +8,51 @@
 package com.qihoo.language;
 
 import com.google.inject.Inject;
+import com.huaban.analysis.jieba.JiebaSegmenter;
 import com.qihoo.language.config.DictsLocConfig;
 import com.yahoo.language.Linguistics;
-import com.yahoo.language.detect.Detector;
-import com.yahoo.language.process.CharacterClasses;
-import com.yahoo.language.process.GramSplitter;
-import com.yahoo.language.process.Normalizer;
+import com.yahoo.language.opennlp.OpenNlpLinguistics;
 import com.yahoo.language.process.Segmenter;
 import com.yahoo.language.process.SegmenterImpl;
 import com.yahoo.language.process.Stemmer;
 import com.yahoo.language.process.StemmerImpl;
 import com.yahoo.language.process.Tokenizer;
-import com.yahoo.language.process.Transformer;
-import com.yahoo.language.simple.SimpleDetector;
-import com.yahoo.language.simple.SimpleNormalizer;
-import com.yahoo.language.simple.SimpleTransformer;
 
 /**
  * Factory of jieba linguistic processor implementations.
  *
  * @author tanzhenghai 
  */
-public class JiebaLinguistics implements Linguistics {
+public class JiebaLinguistics extends OpenNlpLinguistics {
 
-    // Threadsafe instances
-    private final Normalizer normalizer;
-    private final Transformer transformer;
-    private final Detector detector;
-    private final CharacterClasses characterClasses;
-    private final GramSplitter gramSplitter;
+
     private final Tokenizer tokenizer;
+    private final Tokenizer queryTokenizer;
 
     @Inject
     public JiebaLinguistics(DictsLocConfig config) {
-        this.normalizer = new SimpleNormalizer();
-        this.transformer = new SimpleTransformer();
-        this.detector = new SimpleDetector();
-        this.characterClasses = new CharacterClasses();
-        this.gramSplitter = new GramSplitter(characterClasses);
-        this.tokenizer = new JiebaTokenizer(config);
+        this.tokenizer = new JiebaTokenizer(config, JiebaSegmenter.SegMode.INDEX);
+        this.queryTokenizer = new JiebaTokenizer(config, JiebaSegmenter.SegMode.SEARCH);
     }
 
     @Override
-    public Stemmer getStemmer() { return new StemmerImpl(getTokenizer()); }
+    public Tokenizer getTokenizer() {
+        return tokenizer;
+    }
 
     @Override
-    public Tokenizer getTokenizer() { return tokenizer; }
+    public Stemmer getStemmer() {
+        return new StemmerImpl(queryTokenizer);
+    }
 
     @Override
-    public Normalizer getNormalizer() { return normalizer; }
+    public Segmenter getSegmenter() {
+        return new SegmenterImpl(queryTokenizer);
+    }
 
     @Override
-    public Transformer getTransformer() { return transformer; }
-
-    @Override
-    public Segmenter getSegmenter() { return new SegmenterImpl(getTokenizer()); }
-
-    @Override
-    public Detector getDetector() { return detector; }
-
-    @Override
-    public GramSplitter getGramSplitter() { return gramSplitter; }
-
-    @Override
-    public CharacterClasses getCharacterClasses() { return characterClasses; }
-
-    @Override public boolean equals(Linguistics other) { return other instanceof JiebaLinguistics; }
-
+    public boolean equals(Linguistics other) {
+        return other instanceof JiebaLinguistics;
+    }
 }
 

--- a/examples/vespa-chinese-linguistics/src/test/java/com/qihoo/language/JiebaTokenizerTest.java
+++ b/examples/vespa-chinese-linguistics/src/test/java/com/qihoo/language/JiebaTokenizerTest.java
@@ -1,5 +1,6 @@
 package com.qihoo.language;
 
+import com.huaban.analysis.jieba.JiebaSegmenter;
 import com.qihoo.language.config.DictsLocConfig;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.StemMode;
@@ -18,7 +19,7 @@ public class JiebaTokenizerTest {
     @Test
     public void testJiebaTokenizer() {
         String text = "e-tron是Audi生产的车";
-        var tokenizer = new JiebaTokenizer(new DictsLocConfig.Builder().build());
+        var tokenizer = new JiebaTokenizer(new DictsLocConfig.Builder().build(), JiebaSegmenter.SegMode.INDEX);
         Iterator<Token> tokens = tokenizer.tokenize(text, Language.CHINESE_SIMPLIFIED, StemMode.ALL, true).iterator();
         assertToken("e", tokens);
         assertToken("-", tokens);


### PR DESCRIPTION
- fix user dict load error(previous version dictionary path should be a resource path, not a absolute file path)
- fix index word not in lower case, word with upper case letter will not match
- fix query tokenizer should use SegMode.SEARCH

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
