### PR TITLE
Set correct container cluster name

### DIFF
--- a/use-case-shopping/src/test/application/tests/system-test/product-search-test.json
+++ b/use-case-shopping/src/test/application/tests/system-test/product-search-test.json
@@ -2,7 +2,7 @@
   "name": "Product Search",
   "comment": "Test of end to end retrieve and read pipeline",
   "defaults": {
-    "cluster": "default",
+    "cluster": "container",
     "parameters": {
       "timeout": "5s"
     }


### PR DESCRIPTION
- fix https://cd.screwdriver.cd/pipelines/7038/builds/894447/steps/run-tests

```
07:54:36 ********************************************************************************
07:54:36 * vespa test src/test/application/tests/system-test/product-search-test.json
07:54:36 * (Expecting 'Success')
07:54:36 ********************************************************************************
07:54:37 Product Search:
07:54:37 Error: error in Step 1: feed product document: no such service: "default": known services: container
07:54:37 Hint: See https://docs.vespa.ai/en/reference/testing
07:54:37 ERROR: Expected output 'Success' not found in command 'vespa test src/test/application/tests/system-test/product-search-test.json'
```