### PR TITLE
Lock to 1.15.1 for now

### DIFF
--- a/msmarco-ranking/src/main/python/model-exporting.ipynb
+++ b/msmarco-ranking/src/main/python/model-exporting.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "!python3 -m pip install torch numpy transformers onnx onnxruntime \"protobuf >=4.24.2, <=4.24.2\""
+    "!python3 -m pip install torch numpy transformers onnx \"onnxruntime==1.15.1\" \"protobuf >=4.24.2, <=4.24.2\""
    ]
   },
   {


### PR DESCRIPTION
- with 1.16.0 we get https://cd.screwdriver.cd/pipelines/7038/builds/899796/steps/run-tests
- works with 1.15.1

```
from transformers import AutoTokenizer, AutoModelForSequenceClassification
04:06:22 import transformers.convert_graph_to_onnx as onnx_convert
04:06:22 
04:06:22 cross_model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
04:06:22 output_file = "ms-marco-MiniLM-L-6-v2.onnx"
04:06:22 tokenizer = AutoTokenizer.from_pretrained(cross_model)
04:06:22 model = AutoModelForSequenceClassification.from_pretrained(cross_model)
04:06:22 model = model.eval()
04:06:22 pipeline = transformers.pipeline("text-classification", model=model, tokenizer=tokenizer)
04:06:22 onnx_convert.convert_pytorch(pipeline, opset=12, output=Path(output_file), use_external_format=False)
04:06:22 onnx_convert.quantize(Path(output_file))
04:06:22 ---------------------------------------------------------------------------
04:06:22 AttributeError                            Traceback (most recent call last)
04:06:22 Cell In[9], line 11
04:06:22       9 pipeline = transformers.pipeline("text-classification", model=model, tokenizer=tokenizer)
04:06:22      10 onnx_convert.convert_pytorch(pipeline, opset=12, output=Path(output_file), use_external_format=False)
04:06:22 ---> 11 onnx_convert.quantize(Path(output_file))
04:06:22 
04:06:22 File /usr/local/lib/python3.9/site-packages/transformers/convert_graph_to_onnx.py:475, in quantize(onnx_model_path)
04:06:22     461     quantizer = ONNXQuantizer(
04:06:22     462         model=copy_model,
04:06:22     463         per_channel=False,
04:06:22    (...)
04:06:22     472         op_types_to_quantize=list(IntegerOpsRegistry),
04:06:22     473     )
04:06:22     474 else:
04:06:22 --> 475     quantizer = ONNXQuantizer(
04:06:22     476         model=copy_model,
04:06:22     477         per_channel=False,
04:06:22     478         reduce_range=False,
04:06:22     479         mode=QuantizationMode.IntegerOps,
04:06:22     480         static=False,
04:06:22     481         weight_qType=True,
04:06:22     482         activation_qType=False,
04:06:22     483         tensors_range=None,
04:06:22     484         nodes_to_quantize=None,
04:06:22     485         nodes_to_exclude=None,
04:06:22     486         op_types_to_quantize=list(IntegerOpsRegistry),
04:06:22     487     )
04:06:22     489 # Quantize and export
04:06:22     490 quantizer.quantize_model()
04:06:22 
04:06:22 File /usr/local/lib64/python3.9/site-packages/onnxruntime/quantization/onnx_quantizer.py:115, in ONNXQuantizer.__init__(self, model, per_channel, reduce_range, mode, static, weight_qType, activation_qType, tensors_range, nodes_to_quantize, nodes_to_exclude, op_types_to_quantize, extra_options)
04:06:22     106 self.is_weight_symmetric = (
04:06:22     107     weight_qType in (QuantType.QInt8, QuantType.QFLOAT8E4M3FN)
04:06:22     108     if "WeightSymmetric" not in self.extra_options
04:06:22     109     else self.extra_options["WeightSymmetric"]
04:06:22     110 )
04:06:22     111 self.is_activation_symmetric = (
04:06:22     112     False if "ActivationSymmetric" not in self.extra_options else self.extra_options["ActivationSymmetric"]
04:06:22     113 )
04:06:22 --> 115 self.activation_qType = activation_qType.tensor_type
04:06:22     116 self.weight_qType = weight_qType.tensor_type
04:06:22     117 """
04:06:22     118     Dictionary specifying the min and max values for tensors. It has following format:
04:06:22     119         {
04:06:22    (...)
04:06:22     126         }
04:06:22     127 """
04:06:22 
04:06:22 AttributeError: 'bool' object has no attribute 'tensor_type'
04:06:22 =========================== short test summary info ============================
04:06:22 FAILED src/main/python/model-exporting.ipynb:: - AttributeError: 'bool' object has no attribute 'tensor_type'
04:06:22 ============================== 1 failed in 22.38s ==============================
04:06:22 ERROR: Expected output '1 passed' not found in command 'python3 -m pytest --nbmake src/main/python/model-exporting.ipynb'
```