### PR TITLE
Use http 1.1, server has misconfigured http 2 setup

### DIFF
--- a/billion-scale-image-search/README.md
+++ b/billion-scale-image-search/README.md
@@ -166,7 +166,7 @@ These instructions use the first split file (0000) of a total of 2314 files in t
 Download the vector data file:
 
 <pre data-test="exec">
-$ curl -L -o img_emb_0000.npy \
+$ curl --http1.1 -L -o img_emb_0000.npy \
   https://the-eye.eu/public/AI/cah/laion5b/embeddings/laion2B-en/img_emb/img_emb_0000.npy
 </pre>
 


### PR DESCRIPTION
Error message when not specifying protocol version (=> will use http 2):

07:51:23 curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
07:51:23 sentinel-254488> exit code: 92
07:51:23 
07:51:23 ERROR: Command 'curl -L -o img_emb_0000.npy  https://the-eye.eu/public/AI/cah/laion5b/embeddings/laion2B-en/img_emb/img_emb_0000.npy' returned code 92
07:51:23 
