### PR TITLE
change msmarco dataset location

### DIFF
--- a/text-search/bin/download-msmarco.sh
+++ b/text-search/bin/download-msmarco.sh
@@ -4,9 +4,9 @@ DIR="msmarco/download"
 
 mkdir -p $DIR
 
-curl -L -o $DIR/msmarco-doctrain-queries.tsv.gz https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-doctrain-queries.tsv.gz
-curl -L -o $DIR/msmarco-doctrain-qrels.tsv.gz https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-doctrain-qrels.tsv.gz
-curl -L -o $DIR/msmarco-docs-lookup.tsv.gz https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-docs-lookup.tsv.gz
-curl -L -o $DIR/msmarco-docs.tsv.gz https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-docs.tsv.gz
+curl -L -o $DIR/msmarco-doctrain-queries.tsv.gz https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco-doctrain-queries.tsv.gz
+curl -L -o $DIR/msmarco-doctrain-qrels.tsv.gz https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco-doctrain-qrels.tsv.gz
+curl -L -o $DIR/msmarco-docs-lookup.tsv.gz https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco-docs-lookup.tsv.gz
+curl -L -o $DIR/msmarco-docs.tsv.gz https://msmarco.blob.z22.web.windows.net/msmarcoranking/msmarco-docs.tsv.gz
 
 gunzip $DIR/msmarco-docs.tsv.gz


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

It seems that the old location for the msmarco datasets is invalid. They have been moved as shown below:

```
~/text-search
❯ curl --head https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-doctrain-queries.tsv.gz
HTTP/1.1 404 The specified resource does not exist.
Transfer-Encoding: chunked
Server: Blob Service Version 1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: 5cd1bf4f-501e-0067-144d-713590000000
Date: Fri, 08 Mar 2024 11:43:48 GMT


~/text-search
❯ curl --head https://msmarco.z22.web.core.windows.net/msmarcoranking/msmarco-doctrain-queries.tsv.gz
HTTP/1.1 200 OK
Content-Length: 6457962
Content-Type: application/x-gzip
Content-MD5: QIbTGpzy17acSTJgkFgRHQ==
Last-Modified: Thu, 09 Nov 2023 20:58:42 GMT
Accept-Ranges: bytes
ETag: "0x8DBE166A7BAD4A3"
Server: Windows-Azure-Web/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: 016cc31b-601e-0020-294d-71eafb000000
x-ms-version: 2018-03-28
Date: Fri, 08 Mar 2024 11:43:55 GMT
```