### PR TITLE
Wait longer for stateless container to start

### DIFF
--- a/commerce-product-ranking/README.md
+++ b/commerce-product-ranking/README.md
@@ -105,7 +105,7 @@ to export models from PyTorch to ONNX format.
 
 Deploy the application:
 <pre data-test="exec" data-test-assert-contains="Success">
-$ vespa deploy --wait 300 application
+$ vespa deploy --wait 600 application
 </pre>
 
 #### Deployment note


### PR DESCRIPTION
Wait longer since it's a constrained environment for testing, and the sample app loads many models.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
