### PR TITLE
feat: add GitHub Actions workflow for link checking on documentation MERGEOK

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,38 @@
+name: Link checker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "00 3 * * 1-5"
+
+jobs:
+  test:
+    uses: vespa-engine/gh-actions/.github/workflows/jekyll-link-checker.yml@remove-redirect-files-before-link-check
+    with:
+      additional-args: "--directory-index-file README.html"
+      add-no-render-with-liquid: "true"
+      build-plugins: |
+        _plugins-linkcheck
+      pre-check-script: |
+        mv links-to-check.html _site
+        echo "Broken links in links-to-check.html are extracted from services/hosts/deployment.xml in the sample apps, as well as links in javadoc."
+        echo "Search for broken links in these files."
+      ignore-files: |-
+        /tensor-playground/src/main/resources/playground/
+        /src/main/resources/site/index.html/
+        /dense-passage-retrieval-with-ann/src/main/resources/frontend/index.html/
+      ignore-urls: |-
+        src/main/application/schemas/wiki.sd#L80
+        /localhost:8080/
+        src/main/application/search/query-profiles
+        /hub.docker.com/r/vespaengine/vespa/tags/
+      swap-urls: |-
+        (https\://github.com.*/master/.*)#.*:\1
+        (https\://github.com.*/main/.*)#.*:\1
+        ^(?!https)(.*)\.md:\1.html

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    uses: vespa-engine/gh-actions/.github/workflows/jekyll-link-checker.yml@remove-redirect-files-before-link-check
+    uses: vespa-engine/gh-actions/.github/workflows/jekyll-link-checker.yml@main
     with:
       additional-args: "--directory-index-file README.html"
       add-no-render-with-liquid: "true"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -20,43 +20,6 @@ shared:
           ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/
 
 jobs:
-  link-checker-sample-apps:
-    requires: [~pr, ~commit]
-    image: ruby:3.1
-    annotations:
-      screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
-    steps:
-      - install: |
-          gem update --system 3.3.3
-          gem install bundler
-          export LANG=C.UTF-8
-          bundle install
-      - add-front-matter-for-processing: |
-          find . -not -path './_site/*' -name \*.md | \
-            while read f; do (echo -e "---\nrender_with_liquid: false\n---\n"; cat ${f})>${f}.new; mv ${f}.new ${f}; done
-          find . -not -path './_site/*' -name services.xml -or -name hosts.xml -or -name deployment.xml | \
-            while read f; do (echo -e "---\nrender_with_liquid: false\n---\n"; cat ${f})>${f}.new; mv ${f}.new ${f}; done
-          find . -not -path './_site/*' -name \*.java -or -not -path './_site/*' -name \*.sd | \
-            while read f; do (echo -e "---\nrender_with_liquid: false\n---\n"; cat ${f})>${f}.new; mv ${f}.new ${f}; done
-      - generate-links-from-code-files: |
-          bundle exec jekyll build -p _plugins-linkcheck
-      - build-site: |
-          bundle exec jekyll build
-          mv links-to-check.html _site
-          echo "Broken links in links-to-check.html are extracted from services/hosts/deployment.xml in the sample apps,"
-          echo "as well as links in javadoc."
-          echo "Search for broken links in these files."
-      - check-links: |
-          bundle exec htmlproofer \
-            --assume-extension --check-html --no-check-external-hash --no-enforce-http \
-            --typhoeus '{"connecttimeout": 10, "timeout": 30, "accept_encoding": "zstd,br,gzip,deflate"}' \
-            --hydra '{"max_concurrency": 1}' \
-            --directory-index-file README.html \
-            --ignore-urls 'src/main/application/schemas/wiki.sd#L80,/localhost:8080/,src/main/application/search/query-profiles,/hub.docker.com/r/vespaengine/vespa/tags/' \
-            --ignore-files '/tensor-playground/src/main/resources/playground/,/src/main/resources/site/index.html/,/dense-passage-retrieval-with-ann/src/main/resources/frontend/index.html/' \
-            --swap-urls '(https\://github.com.*/master/.*)#.*:\1,(https\://github.com.*/main/.*)#.*:\1,^(?!https)(.*)\.md:\1.html' \
-            _site
-
   verify-billion-scale-vector-search:
     requires: [~pr, ~commit]
     sourcePaths: ["billion-scale-vector-search/"]


### PR DESCRIPTION
## What

- Setup a Github Actions workflow to check documentation links.
- Removed the existing job from Screwdriver

## Why

Migrate the ["link-checker" Screwdriver](https://github.com/vespa-engine/sample-apps/blob/1ff9e32788ecb8d9bee4f6cb3abb7337343439a0/screwdriver.yaml#L23-L58) job to Github Actions.

## Additional Info

More PRs using the same `jekyll-link-checker.yml` workflow:
- https://github.com/vespaai/blog/pull/545
- https://github.com/vespa-engine/documentation/pull/3299

---

> ⚠️ Requires PR to be merged first: https://github.com/vespa-engine/gh-actions/pull/6