### PR TITLE
chore: migrate workflow for building sample apps to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+---
+name: Build Sample Apps
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Build
+        run: |
+          mvn -V --batch-mode --no-snapshot-updates install

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,7 +1,7 @@
 shared:
   settings:
     email:
-      addresses: [kraune@yahooinc.com,bergum@yahooinc.com]
+      addresses: [kraune@yahooinc.com, bergum@yahooinc.com]
       statuses: [SUCCESS, FAILURE]
   environment:
     USER_SHELL_BIN: bash
@@ -57,35 +57,6 @@ jobs:
             --swap-urls '(https\://github.com.*/master/.*)#.*:\1,(https\://github.com.*/main/.*)#.*:\1,^(?!https)(.*)\.md:\1.html' \
             _site
 
-  build-apps:
-    requires: [~pr, ~commit]
-    image: vespaengine/vespa-build-almalinux-8:latest
-    annotations:
-      screwdriver.cd/cpu: HIGH
-      screwdriver.cd/ram: HIGH
-    steps:
-      - build: |
-          set -e
-          mvn -V --batch-mode --no-snapshot-updates install
-
-  verify-guides:
-    requires: [~pr, ~commit]
-    sourcePaths: ["!billion-scale-vector-search/", "!billion-scale-image-search/", "!screwdriver.yml", "!examples/model-deployment/"]
-    image: vespaengine/vespa-build-almalinux-8:latest
-    annotations:
-      screwdriver.cd/cpu: TURBO
-      screwdriver.cd/ram: TURBO
-      screwdriver.cd/dockerEnabled: true
-      screwdriver.cd/dockerCpu: TURBO
-      screwdriver.cd/dockerRam: TURBO
-      screwdriver.cd/timeout: 180
-      screwdriver.cd/buildPeriodically: H H(0-5) * * 1-5 # some time between 12:00 AM UTC (midnight) to 5:59 AM UTC Mon-Fri
-    steps:
-      - *install-deps
-      - run-tests: |
-          cd $SD_DIND_SHARE_PATH
-          $SD_SOURCE_DIR/test/test.py -v -w $SD_SOURCE_DIR -c $SD_SOURCE_DIR/test/_test_config.yml
-
   verify-billion-scale-vector-search:
     requires: [~pr, ~commit]
     sourcePaths: ["billion-scale-vector-search/"]
@@ -123,8 +94,8 @@ jobs:
           $SD_SOURCE_DIR/test/test.py -w $SD_SOURCE_DIR $SD_SOURCE_DIR/billion-scale-image-search/README.md
 
   verify-notebooks:
-    requires: [~commit,~pr]
-    sourcePaths: [ "examples/model-deployment/","text-image-search/" ]
+    requires: [~commit, ~pr]
+    sourcePaths: ["examples/model-deployment/", "text-image-search/"]
     image: vespaengine/vespa-build-almalinux-8:latest
     annotations:
       screwdriver.cd/timeout: 120


### PR DESCRIPTION
## What

- adds a new workflow that tests the building of the sample apps
- removes the job from screwdriver

## Why

Part of the process of retiring Screwdriver as CI/CD runner.

## Additional Info

Related PRs:
- https://github.com/vespa-engine/documentation/pull/3295
- https://github.com/vespa-engine/documentation/pull/3296
- https://github.com/vespa-engine/documentation/pull/3301