### PR TITLE
chore: replace deprecated endpoints for vespa feeding and documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,11 +32,11 @@ search:
     - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    # vespacloud-docsearch // aws // us-west-1a
+    # vespacloud-docsearch // aws // eu-west-1a
     - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
     - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json

--- a/_config.yml
+++ b/_config.yml
@@ -24,18 +24,23 @@ search:
   do_feed  : true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - vespaapps_index.json

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -14,11 +14,11 @@ search:
     - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
-    # vespacloud-docsearch // aws // us-west-1a
+    # vespacloud-docsearch // aws // eu-west-1a
     - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
-    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
     - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json

--- a/_paragraphs_config.yml
+++ b/_paragraphs_config.yml
@@ -6,18 +6,23 @@ search:
   do_feed  : true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
-      indexes:
-        - paragraph_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // aws // us-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - paragraph_index.json
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - paragraph_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -6,18 +6,23 @@ search:
   do_feed  : true
   do_index_removal_before_feed: false
   feed_endpoints:
-    - url: https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud/
-      indexes:
-        - suggestions_index.json 
-    - url: https://enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/
+    # vespacloud-docsearch // aws // us-east-1c
+    - url: https://b671e1db.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
-    - url: https://enclave.vespacloud-docsearch.vespa-team.gcp-us-central1-f.z.vespa-app.cloud/
+    # vespacloud-docsearch // gcp // us-central1-f
+    - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // aws // us-west-1a
+    - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
+      indexes:
+        - suggestions_index.json
+    # vespacloud-docsearch // gcp (enclave) // us-central1-f
+    - url: https://ac5f3559.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json

--- a/_suggestions_config.yml
+++ b/_suggestions_config.yml
@@ -14,11 +14,11 @@ search:
     - url: https://a341952a.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
-    # vespacloud-docsearch // aws // us-west-1a
+    # vespacloud-docsearch // aws // eu-west-1a
     - url: https://ed053d52.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json
-    # vespacloud-docsearch // aws (enclave) // us-west-1a
+    # vespacloud-docsearch // aws (enclave) // us-west-1c
     - url: https://f10d3607.b68a8c0d.z.vespa-app.cloud/
       indexes:
         - suggestions_index.json

--- a/examples/google-cloud/cloud-functions/README.md
+++ b/examples/google-cloud/cloud-functions/README.md
@@ -54,11 +54,11 @@ $ gcloud functions deploy get-page-tls \
 ```
 Test using:
 ```
-$ curl --data '{"url":"https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/document/v1/open/doc/docid"}' \
+$ curl --data '{"url":"https://c360c4e6.b68a8c0d.g.vespa-app.cloud//document/v1/open/doc/docid"}' \
   https://get-page-tls-abc5tvbrvq-ew.a.run.app
 
 $ curl -v --data '{
-  "url":"https://vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/document/v1/open/doc/docid",
+  "url":"https://c360c4e6.b68a8c0d.g.vespa-app.cloud//document/v1/open/doc/docid",
   "bucket":"my_bucket",
   "object":"my_docs"}' \
   https://store-page-abc5tvbrvq-ew.a.run.app
@@ -67,7 +67,7 @@ $ curl --max-time 60 --data '{
   "contentCluster":"documentation",
   "chunkCount":100,
   "selection":"doc",
-  "endpoint":"https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud"}' \
+  "endpoint":"https://c360c4e6.b68a8c0d.g.vespa-app.cloud/"}' \
   https://visit-abc5tvbrvq-ew.a.run.app
 ```
 To install - in same directory:
@@ -90,7 +90,7 @@ $ curl --max-time 60 --data '{
   "contentCluster":"documentation",
   "chunkCount":100,
   "selection":"doc",
-  "endpoint":"https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud"}' \
+  "endpoint":"https://c360c4e6.b68a8c0d.g.vespa-app.cloud/"}' \
   https://backup-abc5tvbrvq-ew.a.run.app
 ```
 

--- a/examples/google-cloud/cloud-functions/go/visit.go
+++ b/examples/google-cloud/cloud-functions/go/visit.go
@@ -141,7 +141,7 @@ func visit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var service Service
-	service.BaseURL = d.Endpoint //"https://vespacloud-docsearch.vespa-team.aws-eu-west-1a.z.vespa-app.cloud"
+	service.BaseURL = d.Endpoint //"https://c360c4e6.b68a8c0d.g.vespa-app.cloud/"
 	service.Cert = cert
 
 	res := visitClusters(vArgs, &service)


### PR DESCRIPTION
## What

- Replace the custom vespa cloud endpoints with the generated ones.

## Why

- The custom endpoints are deprecated and will be removed in the future.

## Additional Info

Related PRs:
- https://github.com/vespa-engine/documentation/pull/3327

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
