### PR TITLE
ignore deps changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,12 @@ name: Build Sample Apps
 on:
   push:
     branches: ["master"]
+    paths-ignore:
+      - Gemfile.lock
   pull_request:
     branches: ["master"]
+    paths-ignore:
+      - Gemfile.lock
 
 defaults:
   run:

--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -2,6 +2,8 @@ name: Vespa Sampleapps Search Feed
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - Gemfile.lock
 
 env:
   DATA_PLANE_PUBLIC_KEY     : ${{ secrets.VESPA_TEAM_DATA_PLANE_PUBLIC_CERT }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - Gemfile.lock
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - Gemfile.lock
   schedule:
     - cron: "00 3 * * 1-5"
 

--- a/.github/workflows/verify-guides-main.yml
+++ b/.github/workflows/verify-guides-main.yml
@@ -10,6 +10,7 @@ on:
       - "billion-scale-image-search/"
       - "examples/model-deployment/"
       - ".github/**"
+      - Gemfile.lock
       - "!.github/workflows/verify-guides-main.yml"
 
   pull_request:
@@ -19,6 +20,7 @@ on:
       - "billion-scale-image-search/"
       - "examples/model-deployment/"
       - ".github/**"
+      - Gemfile.lock
       - "!.github/workflows/verify-guides-main.yml"
 
 jobs:


### PR DESCRIPTION
Gemfile.lock is only used when generating the feed to doc search, so we _could_ feed on changes to it. But we will find out soon enough if something breaks on deps, and it is wasteful to generate the feed job for every dep change, that is quite often