### PR TITLE
(colpalidemo) poll individual sim map

### DIFF
--- a/visual-retrieval-colpali/frontend/app.py
+++ b/visual-retrieval-colpali/frontend/app.py
@@ -204,6 +204,27 @@ def LoadingMessage():
     )
 
 
+def SimMapButtonReady(query_id, idx, token, img_src):
+    return Button(
+        token,
+        size="sm",
+        data_image_src=img_src,
+        id=f"sim-map-button-{query_id}-{idx}-{token}",
+        cls="sim-map-button pointer-events-auto font-mono text-xs h-5 rounded-none px-2",
+    )
+
+
+def SimMapButtonPoll(query_id, idx, token):
+    return Button(
+        Lucide(icon="loader-circle", size="15", cls="animate-spin"),
+        size="sm",
+        disabled=True,
+        hx_get=f"/get_sim_map?query_id={query_id}&idx={idx}&token={token}",
+        hx_trigger="every 1s",
+        hx_swap="outerHTML",
+    )
+
+
 def SearchResult(results: list, query_id: Optional[str] = None):
     if not results:
         return Div(
@@ -216,7 +237,7 @@ def SearchResult(results: list, query_id: Optional[str] = None):
 
     # Otherwise, display the search results
     result_items = []
-    for result in results:
+    for idx, result in enumerate(results):
         fields = result["fields"]  # Extract the 'fields' part of each result
         full_image_base64 = f"data:image/jpeg;base64,{fields['full_image']}"
 
@@ -224,21 +245,30 @@ def SearchResult(results: list, query_id: Optional[str] = None):
         sim_map_fields = {
             key: value
             for key, value in fields.items()
-            if key.startswith("sim_map_") and len(key.split("_")[-1]) >= 4
+            if key.startswith(
+                "sim_map_"
+            )  # filtering is done before creating with 'is_special_token'-function
         }
 
         # Generate buttons for the sim_map fields
         sim_map_buttons = []
         for key, value in sim_map_fields.items():
-            sim_map_base64 = f"data:image/jpeg;base64,{value}"
-            sim_map_buttons.append(
-                Button(
-                    key.split("_")[-1],
-                    size="sm",
-                    data_image_src=sim_map_base64,
-                    cls="sim-map-button pointer-events-auto font-mono text-xs h-5 rounded-none px-2",
+            if value is not None:
+                sim_map_base64 = f"data:image/jpeg;base64,{value}"
+                sim_map_buttons.append(
+                    SimMapButtonReady(
+                        query_id=query_id,
+                        idx=idx,
+                        token=key.split("_")[-1],
+                        image_src=sim_map_base64,
+                    )
                 )
-            )
+            else:
+                sim_map_buttons.append(
+                    SimMapButtonPoll(
+                        query_id=query_id, idx=idx, token=key.split("_")[-1]
+                    )
+                )
 
         # Add "Reset Image" button to restore the full image
         reset_button = Button(
@@ -249,11 +279,7 @@ def SearchResult(results: list, query_id: Optional[str] = None):
             cls="reset-button pointer-events-auto font-mono text-xs h-5 rounded-none px-2",
         )
 
-        tokens_icon = (
-            Lucide(icon="loader-circle", size="15", cls="animate-spin")
-            if query_id is not None
-            else Lucide(icon="images", size="15")
-        )
+        tokens_icon = Lucide(icon="images", size="15")
 
         # Add "Tokens" button - this has no action, just a placeholder
         tokens_button = Button(
@@ -307,22 +333,9 @@ def SearchResult(results: list, query_id: Optional[str] = None):
                 cls="grid grid-cols-1 md:grid-cols-2 col-span-2",
             )
         )
-
-    if query_id is not None:
-        return Div(
-            *result_items,
-            image_swapping,
-            hx_get=f"/updated_search_results?query_id={query_id}",
-            hx_trigger="every 1s",
-            hx_target="#search-results",
-            hx_swap="outerHTML",
-            id="search-results",
-            cls="grid grid-cols-2 gap-px bg-border",
-        )
-    else:
-        return Div(
-            *result_items,
-            image_swapping,
-            id="search-results",
-            cls="grid grid-cols-2 gap-px bg-border",
-        )
+    return Div(
+        *result_items,
+        image_swapping,
+        id="search-results",
+        cls="grid grid-cols-2 gap-px bg-border",
+    )

--- a/visual-retrieval-colpali/main.py
+++ b/visual-retrieval-colpali/main.py
@@ -11,11 +11,19 @@ from backend.colpali import (
     get_result_from_query,
     get_query_embeddings_and_token_map,
     add_sim_maps_to_result,
+    is_special_token,
 )
 from backend.vespa_app import get_vespa_app
 from backend.cache import LRUCache
 from backend.modelmanager import ModelManager
-from frontend.app import Home, Search, SearchBox, SearchResult
+from frontend.app import (
+    Home,
+    Search,
+    SearchBox,
+    SearchResult,
+    SimMapButtonPoll,
+    SimMapButtonReady,
+)
 from frontend.layout import Layout
 import hashlib
 
@@ -143,7 +151,15 @@ async def get(request, query: str, nn: bool = True):
             model, processor, query, q_embs, token_to_idx, result, query_id
         )
     )
+    fields_to_add = [
+        f"sim_map_{token}"
+        for token in token_to_idx.keys()
+        if not is_special_token(token)
+    ]
     search_results = get_results_children(result)
+    for result in search_results:
+        for sim_map_key in fields_to_add:
+            result["fields"][sim_map_key] = None
     return SearchResult(search_results, query_id)
 
 
@@ -176,18 +192,29 @@ async def generate_similarity_map(
     task_cache.set(query_id, True)
 
 
-@app.get("/updated_search_results")
-async def updated_search_results(query_id: str):
+@app.get("/get_sim_map")
+async def get_sim_map(query_id: str, idx: int, token: str):
+    """
+    Endpoint that each of the sim map button polls to get the sim map image
+    when it is ready. If it is not ready, returns a SimMapButtonPoll, that
+    continues to poll every 1 second.
+    """
     result = result_cache.get(query_id)
     if result is None:
-        return HTMLResponse(status_code=204)
+        return SimMapButtonPoll(query_id=query_id, idx=idx, token=token)
     search_results = get_results_children(result)
-    # Check if task is completed - Stop polling if it is
-    if task_cache.get(query_id):
-        updated_content = SearchResult(results=search_results, query_id=None)
+    # Check if idx exists in list of children
+    if idx >= len(search_results):
+        return SimMapButtonPoll(query_id=query_id, idx=idx, token=token)
     else:
-        updated_content = SearchResult(results=search_results, query_id=query_id)
-    return updated_content
+        sim_map_key = f"sim_map_{token}"
+        sim_map_b64 = search_results[idx]["fields"].get(sim_map_key, None)
+        if sim_map_b64 is None:
+            return SimMapButtonPoll(query_id=query_id, idx=idx, token=token)
+        sim_map_img_src = f"data:image/jpeg;base64,{sim_map_b64}"
+        return SimMapButtonReady(
+            query_id=query_id, idx=idx, token=token, img_src=sim_map_img_src
+        )
 
 
 @rt("/app")


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fixes DOM reset when polling for whole `SearchResult` by making each individual sim map button poll for its own button when it is ready. 
Also moved the loading from the "Tokens" button to each of the individual tokens. 
Deployed to HF just to see if it could make it faster as well, and it seems much faster. 
 The Iframe on HF probably didn't like to reload 20/30 large images every second. 😅 