### PR TITLE
Add missing backslashes to README.md

### DIFF
--- a/retrieval-augmented-generation/README.md
+++ b/retrieval-augmented-generation/README.md
@@ -162,8 +162,8 @@ To test generation using the OpenAI client, post a query which runs
 the `openai` search chain:
 <pre>
 $ vespa query \
-    --timeout 60
-    --header="X-LLM-API-KEY:insert-api-key-here"
+    --timeout 60 \
+    --header="X-LLM-API-KEY:insert-api-key-here" \
     query="what was the manhattan project?" \
     hits=5 \
     searchChain=openai \


### PR DESCRIPTION
One of the queries is missing two line continuation characters. Tested on macOS with Zsh.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
