### PR TITLE
(colpalidemo) Thomasht86/exploreadditionalhits

### DIFF
--- a/visual-retrieval-colpali/src/backend/vespa_app.py
+++ b/visual-retrieval-colpali/src/backend/vespa_app.py
@@ -115,6 +115,7 @@ class VespaQueryClient:
     ) -> dict:
         """
         Query Vespa using the default ranking profile.
+        This corresponds to the "Hybrid ColPali+BM25" radio button in the UI.
 
         Args:
             query (str): The query text.
@@ -162,6 +163,7 @@ class VespaQueryClient:
     ) -> dict:
         """
         Query Vespa using the BM25 ranking profile.
+        This corresponds to the "BM25" radio button in the UI.
 
         Args:
             query (str): The query text.
@@ -430,6 +432,7 @@ class VespaQueryClient:
     ) -> dict:
         """
         Query Vespa using nearest neighbor search with mixed tensors for MaxSim calculations.
+        This corresponds to the "ColPali" radio button in the UI.
 
         Args:
             query (str): The query text.
@@ -470,6 +473,7 @@ class VespaQueryClient:
                     "hits": hits,
                     "query": query,
                     "hnsw.exploreAdditionalHits": hnsw_explore_additional_hits,
+                    "ranking.rerankCount": 100,
                     **kwargs,
                 },
             )

--- a/visual-retrieval-colpali/src/backend/vespa_app.py
+++ b/visual-retrieval-colpali/src/backend/vespa_app.py
@@ -422,6 +422,7 @@ class VespaQueryClient:
         query: str,
         q_emb: torch.Tensor,
         target_hits_per_query_tensor: int = 100,
+        hnsw_explore_additional_hits: int = 300,
         hits: int = 3,
         timeout: str = "10s",
         sim_map: bool = False,
@@ -468,6 +469,7 @@ class VespaQueryClient:
                     "timeout": timeout,
                     "hits": hits,
                     "query": query,
+                    "hnsw.exploreAdditionalHits": hnsw_explore_additional_hits,
                     **kwargs,
                 },
             )


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

We discovered that the globally most similar documents were sometimes not in the top 10 (thus not reranked for second phase) for the `Colpali` radio button (Retrieval binary-> 1st phase `max_sim_binary`-> 2nd phase `max_sim`). 

- Increased `rerankCount` to 100 for `Colpali` rank option
- Added `hnsw.exploreAdditionalHits` to increase accuracy in retrieval. 

This makes this option quite a bit slower, but increases accuracy. 
Thinking that it is good to show tradeoff options. 

Still not sure which one should be default though...?