### PR TITLE
Add sample application pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ also [PyVespa examples](https://pyvespa.readthedocs.io/en/latest/examples.html).
 The [album-recommendation](album-recommendation/) is the intro application to Vespa.
 Learn how to configure the schema for simple recommendation and search use cases.
 
+### Vector Search
+There is a growing interest in AI-powered vector representations of unstructured multimodal data
+and searching efficiently over these representations.
+[vector-search](https://github.com/vespa-cloud/vector-search)
+describes how your organization can unlock the full potential of multimodal AI-powered vector representations
+using Vespa Cloud - the industry-leading managed Vector Search Service.
+
 ### Simple hybrid semantic search
 The [simple semantic search](simple-semantic-search/)
 application demonstrates indexed vector search using `HNSW`, 
@@ -102,6 +109,21 @@ using Vespa as a stateless ML model inference server
 where Vespa takes care of distributing ML models to multiple serving containers,
 offering horizontal scaling and safe deployment.
 Model versioning and feature processing pipeline.
+
+### Vespa Documentation Search
+[vespa-documentation-search](https://github.com/vespa-cloud/vespa-documentation-search)
+is the search application that powers [search.vespa.ai](https://search.vespa.ai/) -
+refer to this for GitHub Actions automation.
+This sample app is a good start for [automated deployments](https://cloud.vespa.ai/en/automated-deployments),
+as it has system, staging and production test examples.
+It uses the [Document API](https://docs.vespa.ai/en/document-api-guide.html)
+both for regular PUT operations but also for UPDATE with _create-if-nonexistent_.
+
+### CORD-19 Search
+[cord19.vespa.ai](https://cord19.vespa.ai/) is a full-featured application,
+based on the [Covid-19 Open Research Dataset](https://huggingface.co/datasets/allenai/cord19):
+* [cord-19](https://github.com/vespa-engine/cord-19): frontend
+* [cord-19-search](https://github.com/vespa-cloud/cord-19-search): search backend
 
 
 <!--

--- a/examples/operations/README.md
+++ b/examples/operations/README.md
@@ -19,8 +19,12 @@ Use the AWS multinode quick-start guides in [getting started](https://docs.vespa
 See [vespa.ai/support](https://vespa.ai/support) for how to get help / FAQ / Stack Overflow.
 [Admin procedures](https://docs.vespa.ai/en/operations/admin-procedures.html) can be a good read, too.
 
-## Multinode applications
+## CI/CD
+Refer to the examples at [CI/CD](https://github.com/vespa-cloud/examples/tree/main/CI-CD)
+for how to add continuous integration and continuous delivery/deployment tests to an application.
 
+
+## Multinode applications
 
 ### Multinode
 The [Multinode](multinode/) application sets up a three-node application and experiment with node start/stop.

--- a/examples/operations/README.md
+++ b/examples/operations/README.md
@@ -20,7 +20,7 @@ See [vespa.ai/support](https://vespa.ai/support) for how to get help / FAQ / Sta
 [Admin procedures](https://docs.vespa.ai/en/operations/admin-procedures.html) can be a good read, too.
 
 ## CI/CD
-Refer to the examples at [CI/CD](https://github.com/vespa-cloud/examples/tree/main/CI-CD)
+Refer to the examples at [CI/CD](CI-CD/)
 for how to add continuous integration and continuous delivery/deployment tests to an application.
 
 


### PR DESCRIPTION
@lperry25 with this, all the sample applications are found from the readme(s) in this repo - so you can change the links in console to https://github.com/vespa-cloud to here instead. A little less confusion.

I will move the applications separately