### PR TITLE
Revert "simplify, not needed"

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -48,15 +48,23 @@ jobs:
         # See https://docs.vespa.ai/en/vespa-cli.html.
         # The environment variables below have credentials for endpoint access -
         # use the key/cert files in .vespa and paste their content into GitHub Secrets.
+        # VESPA_CLI_API_KEY must be set and empty as below.
         export VESPA_CLI_DATA_PLANE_CERT
         export VESPA_CLI_DATA_PLANE_KEY
+        export VESPA_CLI_API_KEY=
         ./feed_to_vespa.py _config.yml
 
     - name: Feed paragraphs site
       run: |
+        export VESPA_CLI_DATA_PLANE_CERT
+        export VESPA_CLI_DATA_PLANE_KEY
+        export VESPA_CLI_API_KEY=
         ./feed-split.py vespaapps_index.json https://github.com/vespa-engine/sample-apps/tree/master questions.jsonl
         ./feed_to_vespa.py _paragraphs_config.yml
 
     - name: Feed suggestions
       run: |
+        export VESPA_CLI_DATA_PLANE_CERT
+        export VESPA_CLI_DATA_PLANE_KEY
+        export VESPA_CLI_API_KEY=
         ./feed_to_vespa.py _suggestions_config.yml


### PR DESCRIPTION
Reverts vespa-engine/sample-apps#1596

feeding not working (will debug after revert): 

```
CompletedProcess(args=['./vespa', 'feed', '-a', 'vespacloud-docsearch.cloud-enclave', '-t', 'https://cloud-enclave.vespacloud-docsearch.vespa-team.aws-us-east-1c.z.vespa-app.cloud/', 'vespaapps_index.json'], returncode=1, stdout=b'', stderr=b'Error: open /home/runner/.vespa/vespacloud-docsearch.api-key.pem: no such file or directory\n')
```
