### PR TITLE
use integers

### DIFF
--- a/test/pseudo_terminal.py
+++ b/test/pseudo_terminal.py
@@ -60,7 +60,7 @@ class PseudoTerminal:
         self._pty.close()
 
     def run(self, command, verbose):
-        command_id = random.randint(10e4, 10e5)
+        command_id = random.randint(10000, 100000)
         sentinel = "sentinel-{0}> exit code: ".format(command_id)
         sentinel_pattern = re.compile(sentinel + "(\d+)")
 


### PR DESCRIPTION
- avoid ERROR: 'float' object cannot be interpreted as an integer

CC @thomasht86  this started failing auto testing, could be the python version was bumped / something made this stricter?