### PR TITLE
add working example of building your own lucene-linguistics component

### DIFF
--- a/examples/lucene-linguistics/add-token-filter-factory/README.md
+++ b/examples/lucene-linguistics/add-token-filter-factory/README.md
@@ -1,0 +1,21 @@
+# Vespa Lucene Linguistics: Adding custom Lucene components
+
+## TL;DR
+
+Shows how you can use an extended version of the lucene-linguistics
+component which includes your own custom components, discoverable
+using the classpath as expected by Lucene SPI mechanism.
+
+## Details
+
+The included pom.xml builds your own component called
+"my-replacement-bundle" which includes a dummy implementation of
+TokenFilterFactory. The class name of the factory must be in
+META-INF/services/org.apache.lucene.analysis.TokenFilterFactory
+from src/main/resources/ directory.
+
+After running "mvn install", you can copy the finished
+target/my-replacement-bundle-1.0.1-deploy.jar to the
+"components" directory in your application package.
+Put the snippet from "services.xml" into your services.xml
+in your application as well to activate it.

--- a/examples/lucene-linguistics/add-token-filter-factory/pom.xml
+++ b/examples/lucene-linguistics/add-token-filter-factory/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!-- Copyright Vespa.ai. All rights reserved. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ai.vespa.test</groupId>
+    <artifactId>my-replacement-bundle</artifactId>
+    <version>1.0.1</version>
+    <packaging>container-plugin</packaging>
+
+    <properties>
+        <!-- Find latest version at search.maven.org/search?q=g:com.yahoo.vespa -->
+        <vespa.version>8.499.20</vespa.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>container</artifactId>
+            <version>${vespa.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>lucene-linguistics</artifactId>
+            <version>${vespa.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.yahoo.vespa</groupId>
+                <artifactId>bundle-plugin</artifactId>
+                <version>${vespa.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/lucene-linguistics/add-token-filter-factory/services.xml
+++ b/examples/lucene-linguistics/add-token-filter-factory/services.xml
@@ -1,0 +1,19 @@
+<!-- use the below instead of component with bundle="lucene-linguistics" -->
+
+<component id="com.yahoo.language.lucene.LuceneLinguistics" bundle="my-replacement-bundle">
+    <config name="com.yahoo.language.lucene.lucene-analysis" >
+        <configDir>analysis-config</configDir>
+        <analysis>
+            <item key="en">
+                <tokenizer>
+                    <name>whitespace</name>
+                </tokenizer>
+                <tokenFilters>
+                    <item>
+                        <name>myFilterFactory</name>
+                    </item>
+                </tokenFilters>
+            </item>
+        </analysis>
+    </config>
+</component>

--- a/examples/lucene-linguistics/add-token-filter-factory/src/main/java/ai/vespa/test/MyFilterFactory.java
+++ b/examples/lucene-linguistics/add-token-filter-factory/src/main/java/ai/vespa/test/MyFilterFactory.java
@@ -1,0 +1,29 @@
+package ai.vespa.test;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.TokenFilterFactory;
+
+import java.util.Map;
+
+public class MyFilterFactory extends TokenFilterFactory {
+
+    public static final String NAME = "myFilterFactory";
+
+    // not actually used, but must be present:
+    public MyFilterFactory() {
+        throw defaultCtorException();
+    }
+
+    public MyFilterFactory(Map<String, String> config) {
+        super(config);
+	// probably plug in some configuration code here
+        System.err.println("Constructed: " + this.getClass());
+    }
+
+    public TokenStream create(TokenStream input) {
+        System.err.println("create called for: " + this.getClass());
+	// actually create your TokenFilter and return that here:
+        return input;
+    }
+
+}

--- a/examples/lucene-linguistics/add-token-filter-factory/src/main/resources/META-INF/services/org.apache.lucene.analysis.TokenFilterFactory
+++ b/examples/lucene-linguistics/add-token-filter-factory/src/main/resources/META-INF/services/org.apache.lucene.analysis.TokenFilterFactory
@@ -1,0 +1,1 @@
+ai.vespa.test.MyFilterFactory


### PR DESCRIPTION
This was the only way I could make plugging in your own TokenFilter components work;
the SPI mechanism used by lucene pretty much requires that these must be in the same
bundle so that they share classloader and classpath.

@bratseth please review
@gjoranv FYI
@radu-gheorghe FYI

@dainiusjocas do you have any comments / insights?
