### PR TITLE
fix: update deployment command to include application path

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -239,7 +239,7 @@ def get_macro(macro):
                 "type": "default"
             },
             {
-                "$": "vespa deploy --wait 300",
+                "$": "vespa deploy --wait 300 ./app",
                 "type": "default"
             }
         ]
@@ -344,7 +344,7 @@ def run_file(file_name):
 
 def run_with_arguments():
     global verbose
-    global workdir 
+    global workdir
     config_file = ""
     argv = sys.argv[1:]
 


### PR DESCRIPTION
## What

* Updates the "init-deploy" macro to use `./app` for vespa deploy commands.

## Why

Use the new directory structure defined in https://github.com/vespa-engine/sample-apps/pull/1670

## Additional info

The following apps needs to be updated with the new structure before the tests are fully passing:

- [ ] colbert-long/
- [ ] examples/lucene-linguistics/non-java/
- [ ] examples/model-exporting/ 
- [ ] splade/