### PR TITLE
marlon/remove-optimize-flag-from-pom

### DIFF
--- a/examples/generic-request-processing/pom.xml
+++ b/examples/generic-request-processing/pom.xml
@@ -45,7 +45,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>11</release>

--- a/examples/http-api-using-request-handlers-and-processors/pom.xml
+++ b/examples/http-api-using-request-handlers-and-processors/pom.xml
@@ -45,7 +45,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>11</release>

--- a/examples/multiple-bundles-lib/pom.xml
+++ b/examples/multiple-bundles-lib/pom.xml
@@ -60,7 +60,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>${jdk.version}</release>

--- a/examples/multiple-bundles/pom.xml
+++ b/examples/multiple-bundles/pom.xml
@@ -125,7 +125,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>${jdk.version}</release>

--- a/examples/operations/monitoring/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
+++ b/examples/operations/monitoring/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
@@ -42,7 +42,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>11</release>

--- a/examples/predicate-fields/pom.xml
+++ b/examples/predicate-fields/pom.xml
@@ -42,7 +42,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <release>11</release>

--- a/use-case-shopping/src/main/java/ai/vespa/example/shopping/SuggestionSearcher.java
+++ b/use-case-shopping/src/main/java/ai/vespa/example/shopping/SuggestionSearcher.java
@@ -4,19 +4,17 @@ package ai.vespa.example.shopping;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.language.Language;
 import com.yahoo.language.Linguistics;
+import com.yahoo.language.process.LinguisticsParameters;
 import com.yahoo.language.process.StemMode;
 import com.yahoo.language.process.Token;
 import com.yahoo.prelude.query.PrefixItem;
-import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.query.FuzzyItem;
 import com.yahoo.prelude.query.OrItem;
 import com.yahoo.prelude.query.Item;
-import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
-import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 
 import java.util.ArrayList;
@@ -48,8 +46,8 @@ public class SuggestionSearcher extends Searcher {
 
     private List<String> tokenize(String userQuery) {
         List<String> result = new ArrayList<>(6);
-        Iterable<Token> tokens = this.linguistics.getTokenizer().
-                tokenize(userQuery, Language.fromLanguageTag("en"), StemMode.NONE,false);
+        Iterable<Token> tokens = this.linguistics.getTokenizer()
+                                         .tokenize(userQuery, new LinguisticsParameters(Language.fromLanguageTag("en"), StemMode.NONE, false, true));
         for(Token t: tokens) {
             if (t.isIndexable())
                 result.add(t.getTokenString());


### PR DESCRIPTION
## What

* Remove the usage of deprecated `tokenize(String, Language, StemMode, boolean)`
* Remove `<optimize>true</optimize>` from maven options

## Why

* Handle deprecations in Vespa 8.502.19
* Handle the warning: _"Parameter 'optimize' (user property 'maven.compiler.optimize') is deprecated: This property is a no-op in javac."_