### PR TITLE
Use 'Vespa' consumer for prometheus cloud config

### DIFF
--- a/examples/operations/monitoring/album-recommendation-monitoring/prometheus/prometheus-cloud.yml
+++ b/examples/operations/monitoring/album-recommendation-monitoring/prometheus/prometheus-cloud.yml
@@ -18,6 +18,8 @@ scrape_configs:
       cert_file: data-plane-public-cert.pem
       key_file: data-plane-private-key.pem
 
+    params:
+      consumer: ['Vespa']
     #Replace <ENDPOINT> with your Vespa Cloud endpoint URL
     static_configs:
       - targets: ['<ENDPOINT>']

--- a/examples/operations/monitoring/vespa-grafana-terraform/modules/alerts/main.tf
+++ b/examples/operations/monitoring/vespa-grafana-terraform/modules/alerts/main.tf
@@ -26,7 +26,6 @@ resource "grafana_rule_group" "vespa_rule_group" {
     name = "Vespa alert group"
     folder_uid = grafana_folder.rule_folder.uid
     interval_seconds = 60
-    org_id = 1
 
     rule {
         name = "content-cluster-disk-util"


### PR DESCRIPTION
And remove unnecessary `org_id`

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
