### PR TITLE
Fix feed.jsonl to match schema for part-purchases-demo

### DIFF
--- a/examples/part-purchases-demo/README.md
+++ b/examples/part-purchases-demo/README.md
@@ -69,6 +69,10 @@ $ vespa status deploy --wait 300
 $ vespa deploy --wait 300
 </pre>
 
+**Generate the feed**
+<pre data-test="exec">
+$ python3 ext/parts.py -f  ext/purchase.csv > ext/feed.jsonl
+</pre>
 
 **Feed to Vespa**
 <pre data-test="exec">

--- a/examples/part-purchases-demo/ext/feed.jsonl
+++ b/examples/part-purchases-demo/ext/feed.jsonl
@@ -1,20 +1,20 @@
-{"fields": {"attributes": {"delivery_method": "Curbside Pickup", "sales_rep": "Bonnie", "coupon": "SAVE10"},"customer": "Smith","date": 1157526000,"item": "Intake valve","price": "1000","tax": "0.24"},"put": "id:purchase:purchase::0"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Bonnie", "coupon": "SPRING5"},"customer": "Smith","date": 1157616000,"item": "Rocker arm","price": "1000","tax": "0.12"},"put": "id:purchase:purchase::1"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Bonnie", "coupon": "VIP25"},"customer": "Smith","date": 1157619600,"item": "Spring","price": "2000","tax": "0.24"},"put": "id:purchase:purchase::2"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Tim", "coupon": "VIP25"},"customer": "Jones","date": 1157709600,"item": "Valve cover","price": "3000","tax": "0.12"},"put": "id:purchase:purchase::3"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Tim", "coupon": "VIP25"},"customer": "Jones","date": 1157702400,"item": "Intake port","price": "5000","tax": "0.24"},"put": "id:purchase:purchase::4"}
-{"fields": {"attributes": {"delivery_method": "Locker Pickup", "sales_rep": "Tim", "coupon": "SPRING5"},"customer": "Brown","date": 1157706000,"item": "Head","price": "8000","tax": "0.12"},"put": "id:purchase:purchase::5"}
-{"fields": {"attributes": {"delivery_method": "Locker Pickup", "sales_rep": "Bonnie", "coupon": "SPRING5"},"customer": "Smith","date": 1157796000,"item": "Coolant","price": "1300","tax": "0.24"},"put": "id:purchase:purchase::6"}
-{"fields": {"attributes": {"delivery_method": "Curbside Pickup", "sales_rep": "Bonnie", "coupon": "WELCOME10"},"customer": "Jones","date": 1157788800,"item": "Engine block","price": "2100","tax": "0.12"},"put": "id:purchase:purchase::7"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Ulrik", "coupon": "WELCOME10"},"customer": "Brown","date": 1157792400,"item": "Oil pan","price": "3400","tax": "0.24"},"put": "id:purchase:purchase::8"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Ulrik", "coupon": "VIP25"},"customer": "Smith","date": 1157796000,"item": "Oil sump","price": "5500","tax": "0.12"},"put": "id:purchase:purchase::9"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Tim", "coupon": "VIP25"},"customer": "Jones","date": 1157875200,"item": "Camshaft","price": "8900","tax": "0.24"},"put": "id:purchase:purchase::10"}
-{"fields": {"attributes": {"delivery_method": "Curbside Pickup", "sales_rep": "Bonnie", "coupon": "SPRING5"},"customer": "Brown","date": 1157878800,"item": "Exhaust valve","price": "1440","tax": "0.12"},"put": "id:purchase:purchase::11"}
-{"fields": {"attributes": {"delivery_method": "Curbside Pickup", "sales_rep": "Bonnie", "coupon": "VIP25"},"customer": "Brown","date": 1157882400,"item": "Rocker arm","price": "2330","tax": "0.24"},"put": "id:purchase:purchase::12"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Bonnie", "coupon": "SPRING5"},"customer": "Brown","date": 1157875200,"item": "Spring","price": "3770","tax": "0.12"},"put": "id:purchase:purchase::13"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Bonnie", "coupon": "SPRING5"},"customer": "Smith","date": 1157878800,"item": "Spark plug","price": "6100","tax": "0.24"},"put": "id:purchase:purchase::14"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Ulrik", "coupon": "VIP25"},"customer": "Jones","date": 1157968800,"item": "Exhaust port","price": "9870","tax": "0.12"},"put": "id:purchase:purchase::15"}
-{"fields": {"attributes": {"delivery_method": "In-Store Pickup", "sales_rep": "Bonnie", "coupon": "VIP25"},"customer": "Brown","date": 1157961600,"item": "Piston","price": "1597","tax": "0.24"},"put": "id:purchase:purchase::16"}
-{"fields": {"attributes": {"delivery_method": "Drone Delivery", "sales_rep": "Ulrik", "coupon": "SPRING5"},"customer": "Smith","date": 1157965200,"item": "Connection rod","price": "2584","tax": "0.12"},"put": "id:purchase:purchase::17"}
-{"fields": {"attributes": {"delivery_method": "Locker Pickup", "sales_rep": "Tim", "coupon": "WELCOME10"},"customer": "Jones","date": 1157968800,"item": "Rod bearing","price": "4181","tax": "0.24"},"put": "id:purchase:purchase::18"}
-{"fields": {"attributes": {"delivery_method": "Locker Pickup", "sales_rep": "Tim", "coupon": "WELCOME10"},"customer": "Jones","date": 1157972400,"item": "Crankshaft","price": "6765","tax": "0.12"},"put": "id:purchase:purchase::19"}
+{"fields": {"customer": "Smith","date": 1157526000,"item": "Intake valve","price": "1000","tax": "0.24"},"put": "id:purchase:purchase::0"}
+{"fields": {"customer": "Smith","date": 1157616000,"item": "Rocker arm","price": "1000","tax": "0.12"},"put": "id:purchase:purchase::1"}
+{"fields": {"customer": "Smith","date": 1157619600,"item": "Spring","price": "2000","tax": "0.24"},"put": "id:purchase:purchase::2"}
+{"fields": {"customer": "Jones","date": 1157709600,"item": "Valve cover","price": "3000","tax": "0.12"},"put": "id:purchase:purchase::3"}
+{"fields": {"customer": "Jones","date": 1157702400,"item": "Intake port","price": "5000","tax": "0.24"},"put": "id:purchase:purchase::4"}
+{"fields": {"customer": "Brown","date": 1157706000,"item": "Head","price": "8000","tax": "0.12"},"put": "id:purchase:purchase::5"}
+{"fields": {"customer": "Smith","date": 1157796000,"item": "Coolant","price": "1300","tax": "0.24"},"put": "id:purchase:purchase::6"}
+{"fields": {"customer": "Jones","date": 1157788800,"item": "Engine block","price": "2100","tax": "0.12"},"put": "id:purchase:purchase::7"}
+{"fields": {"customer": "Brown","date": 1157792400,"item": "Oil pan","price": "3400","tax": "0.24"},"put": "id:purchase:purchase::8"}
+{"fields": {"customer": "Smith","date": 1157796000,"item": "Oil sump","price": "5500","tax": "0.12"},"put": "id:purchase:purchase::9"}
+{"fields": {"customer": "Jones","date": 1157875200,"item": "Camshaft","price": "8900","tax": "0.24"},"put": "id:purchase:purchase::10"}
+{"fields": {"customer": "Brown","date": 1157878800,"item": "Exhaust valve","price": "1440","tax": "0.12"},"put": "id:purchase:purchase::11"}
+{"fields": {"customer": "Brown","date": 1157882400,"item": "Rocker arm","price": "2330","tax": "0.24"},"put": "id:purchase:purchase::12"}
+{"fields": {"customer": "Brown","date": 1157875200,"item": "Spring","price": "3770","tax": "0.12"},"put": "id:purchase:purchase::13"}
+{"fields": {"customer": "Smith","date": 1157878800,"item": "Spark plug","price": "6100","tax": "0.24"},"put": "id:purchase:purchase::14"}
+{"fields": {"customer": "Jones","date": 1157968800,"item": "Exhaust port","price": "9870","tax": "0.12"},"put": "id:purchase:purchase::15"}
+{"fields": {"customer": "Brown","date": 1157961600,"item": "Piston","price": "1597","tax": "0.24"},"put": "id:purchase:purchase::16"}
+{"fields": {"customer": "Smith","date": 1157965200,"item": "Connection rod","price": "2584","tax": "0.12"},"put": "id:purchase:purchase::17"}
+{"fields": {"customer": "Jones","date": 1157968800,"item": "Rod bearing","price": "4181","tax": "0.24"},"put": "id:purchase:purchase::18"}
+{"fields": {"customer": "Jones","date": 1157972400,"item": "Crankshaft","price": "6765","tax": "0.12"},"put": "id:purchase:purchase::19"}


### PR DESCRIPTION
Includes:
- regenerated feed.jsonl using parts.py and the provided CSV file
- updated the project instructions to clarify the need to run parts.py to generate the feed file before
