### PR TITLE
fix: use correct Cloudfront cache invalidation path

### DIFF
--- a/.github/workflows/update-cloud-samples.yml
+++ b/.github/workflows/update-cloud-samples.yml
@@ -156,4 +156,5 @@ jobs:
         env:
           ECHO: ${{ env.DRY_RUN == 'true' && 'echo' || '' }}
         run: |
-          $ECHO aws cloudfront create-invalidation --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" --paths "${S3_UPLOAD_PREFIX}/*" --output text
+          set -x
+          $ECHO aws cloudfront create-invalidation --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" --paths "/${S3_UPLOAD_PREFIX}/*" --output text


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
