### PR TITLE
Remove feed of purchase example, since it is handled in vespa-documentation-search

### DIFF
--- a/.github/workflows/feed.yml
+++ b/.github/workflows/feed.yml
@@ -60,8 +60,3 @@ jobs:
       run: |
         ./feed_to_vespa.py _suggestions_config.yml
 
-    - name: Feed part-purchases-demo
-      run: |
-        while IFS=, read -r app endpoint; do
-          vespa feed -a "$app" -t "$endpoint" examples/part-purchases-demo/ext/feed.jsonl
-        done < <(./scripts/print-app-endpoints.py _config.yml)


### PR DESCRIPTION
Previously added feeding purchase data to the documentation search from the vespa-documentation-search repo.

This repo contains stale purchase data from what is used in the grouping documentation.

Solves the problem by feeding only from vespa-documentation-search.

@kkraune fyi
@thomasht86 fyi
@hmusum please review
