### PR TITLE
chore: update dependencies to fix CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby '>=2.6'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'jekyll', '>= 4.2.1'
+gem 'jekyll', '>= 4.3.3'
 
 # Get the html-proofer to work
 gem 'rake'
-gem 'html-proofer'
+gem 'html-proofer', '>= 5.0.8'

--- a/examples/ecommerce-user-preferences/webapp/templates/index.html
+++ b/examples/ecommerce-user-preferences/webapp/templates/index.html
@@ -145,7 +145,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Lightweight Markdown rendering (assistant messages only) -->
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**

## Summary

Updates dependency version constraints to address known CVEs:
- Bumps `jekyll` minimum version to `>= 4.3.3` in `Gemfile` (CVE-2026-35611)
- Bumps `html-proofer` minimum version to `>= 5.0.8` in `Gemfile` (CVE-2026-35611)
- Pins `marked` CDN to version `15.0.12` in `ecommerce-user-preferences/webapp/templates/index.html` (CVE-2026-41680)
- `DOMPurify` CDN was already pinned to `3.1.6` — no change needed (CVE-2026-41238, CVE-2026-41239 — confirmed safe)

## Changed Files

### `Gemfile`
- `jekyll`: `>= 4.2.1` → `>= 4.3.3` (addresses CVE-2026-35611)
- `html-proofer`: unversioned → `>= 5.0.8` (addresses CVE-2026-35611)

### `examples/ecommerce-user-preferences/webapp/templates/index.html`
- `marked` CDN: unpinned `marked/marked.min.js` → `marked@15.0.12/marked.min.js` (addresses CVE-2026-41680)
- `DOMPurify@3.1.6` was already pinned and is already used correctly — `app.js` calls `DOMPurify.sanitize()` on all `marked.parse()` output before assigning to `innerHTML`. No change was needed.

## CVEs Addressed

- CVE-2026-35611 — jekyll / html-proofer
- CVE-2026-41680 — marked (CDN pin)
- CVE-2026-41238, CVE-2026-41239 — DOMPurify (already safe, no change)

## ⚠️ Review Notes

- The `marked` CDN was previously **unpinned** (floating latest), which is a supply-chain risk. It is now pinned to `15.0.12`.
- DOMPurify was already pinned at `3.1.6` on `master` and is actively used in `app.js` to sanitize all HTML before insertion — confirmed safe.
- Gemfile version constraints use `>=` (lower bounds), not exact pins. Any compatible newer version will be resolved by Bundler. Verify this is acceptable for your CI/CD policy.

## Verification

- [ ] Run `bundle install` and verify no conflicts with updated gem constraints
- [ ] Run the link-checker workflow to confirm html-proofer still works
- [ ] Verify the ecommerce-user-preferences app renders markdown correctly with pinned marked 15.0.12
- [ ] Confirm CDN URLs resolve correctly: `https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)