### PR TITLE
chore: bump dompurify CDN to 3.4.0 to fix CVE-2026-41238 and CVE-2026-41239

### DIFF
--- a/examples/ecommerce-user-preferences/webapp/templates/index.html
+++ b/examples/ecommerce-user-preferences/webapp/templates/index.html
@@ -146,7 +146,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Lightweight Markdown rendering (assistant messages only) -->
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html> 


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**

## Summary
Bumps the `dompurify` jsdelivr CDN URL in the `ecommerce-user-preferences` example from `3.1.6` to `3.4.0`, addressing two XSS bypass advisories flagged by Mend (VESPANG-3271, VESPANG-3201).

## Why this PR exists (despite #1904 being merged)

PR #1904 (merged 2026-04-29) is titled `chore: update dependencies to fix CVEs` and lists CVE-2026-41238 and CVE-2026-41239 in its title and commit message. However, that PR's actual change for DOMPurify was a no-op — it kept the CDN URL at `dompurify@3.1.6`, which sits **inside** the GHSA vulnerable range (`>=3.0.1, <3.4.0`). The first patched version is `3.4.0`.

This PR makes the actual remediation: a one-line CDN URL bump from `3.1.6` → `3.4.0`.

## Changed Files

**`examples/ecommerce-user-preferences/webapp/templates/index.html`** — CDN URL bump:
- `dompurify`: `3.1.6` → `3.4.0` (CVE-2026-41238, CVE-2026-41239)

This is the only DOMPurify reference in the repo (verified via `grep -r dompurify`). No package-lock.json or yarn.lock involved — it's a CDN script tag.

## CVEs Addressed

Verified against the GitHub Advisory Database:

| Package | CVE(s) | GHSA | Severity | Vulnerable range | First patched | Resolved |
|---|---|---|---|---|---|---|
| dompurify | CVE-2026-41238 | GHSA-v9jr-rg53-9pgp | MODERATE | `>=3.0.1, <3.4.0` | 3.4.0 | 3.4.0 |
| dompurify | CVE-2026-41239 | GHSA-crv5-9vww-q3g8 | MODERATE | `>=1.0.10, <3.4.0` | 3.4.0 | 3.4.0 |

Before/after transition: `main` resolves `dompurify@3.1.6` (vulnerable), this branch resolves `dompurify@3.4.0` (patched). Real version change confirmed via `git diff`.

## Implementation Notes

- DOMPurify's `sanitize(html, options)` API is stable across the 3.x series. The two call sites (`messageContent.innerHTML = DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });` in `app.js`) work unchanged on 3.4.0.
- jsdelivr serves `dompurify@3.4.0/dist/purify.min.js` (verified via `HEAD` → 200).
- No SRI integrity attribute was on the previous tag, so none is added here to keep the diff minimal. SRI hardening can be a follow-up if desired.

## Verification

- `grep -r 'dompurify\|DOMPurify\|purify@' .` → exactly one CDN URL, now at `@3.4.0`
- `curl -sI https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js` → `HTTP/2 200`
- Re-run the Mend scan on `master` after merge to confirm both CVEs clear from VESPANG-3271 / VESPANG-3201
- Recommended smoke test: load the ecommerce-user-preferences webapp and confirm assistant chat messages still render markdown correctly