### PR TITLE
Add reverse image search sample app

### DIFF
--- a/reverse-image-search/.gitignore
+++ b/reverse-image-search/.gitignore
@@ -1,0 +1,8 @@
+application.zip
+security
+.idea/
+data/
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/reverse-image-search/README.md
+++ b/reverse-image-search/README.md
@@ -1,0 +1,185 @@
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://assets.vespa.ai/logos/Vespa-logo-green-RGB.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://assets.vespa.ai/logos/Vespa-logo-dark-RGB.svg">
+  <img alt="#Vespa" width="200" src="https://assets.vespa.ai/logos/Vespa-logo-dark-RGB.svg" style="margin-bottom: 25px;">
+</picture>
+
+# Vespa sample application - Reverse Image Search
+
+## Short description
+Reverse Image Search takes an input **image** and returns visually similar images from an indexed
+corpus. Embeddings come from [DINOv2](https://github.com/facebookresearch/dinov2)
+(`facebook/dinov2-base`, 768-d CLS, L2-normalized). The schema stores both the float embedding
+(used for second-phase rerank) and a server-side derived binary embedding (used for cheap HNSW
+first-phase retrieval over Hamming distance).
+
+The original images are inlined inside Vespa as base64 `raw` bytes (`full_image`), so the index is
+the single source of truth for vectors, metadata, and image bytes.
+
+
+## Features
+- DINOv2 (`facebook/dinov2-base`) image embeddings — 768-d, L2-normalized.
+- **Binary HNSW** first-phase retrieval over a server-derived `tensor<int8>(x[96])` field
+  (768 signed bits packed into 96 int8s via `| binarize | pack_bits`), Hamming distance.
+- **Float rerank** in second phase using a `tensor<bfloat16>(x[768])` `paged` attribute —
+  ~16× less memory than an HNSW-indexed in-memory float attribute.
+- Five rank profiles (`closeness`, `closeness_hybrid_strict`, `closeness_binary`,
+  `closeness_weighted`, plus `unranked`/`random`) so you can compare hybrid binary+float retrieval
+  against binary-only or weighted blends.
+- JPEG bytes inlined as `full_image` — Vespa serves both the search index and the image payload.
+
+
+## Quick start
+The dataset is [ILSVRC/imagenet-1k](https://huggingface.co/datasets/ILSVRC/imagenet-1k) (1.28M
+train + 50K validation images), streamed from HuggingFace, embedded with DINOv2 on the client,
+then fed to Vespa with the JPEG bytes inlined.
+
+Requirements:
+* [Docker](https://www.docker.com/) Desktop installed and running. 8 GB available memory for Docker
+  is recommended for a small subset; the full corpus needs Vespa Cloud (see
+  [Vespa Cloud notes](#vespa-cloud-notes)).
+  Refer to [Docker memory](https://docs.vespa.ai/en/operations-selfhosted/docker-containers.html#memory)
+  for details and troubleshooting.
+* Operating system: Linux, macOS or Windows 10 Pro (Docker requirement).
+* Architecture: x86_64 or arm64.
+* [Homebrew](https://brew.sh/) to install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html), or
+  download a Vespa CLI release from [GitHub releases](https://github.com/vespa-engine/vespa/releases).
+* Python 3.11+ with `pip` (for the feeder and the search CLI).
+* A HuggingFace token with access to `ILSVRC/imagenet-1k` (gated dataset). Set it as `HF_TOKEN`
+  before running the feeder.
+
+Validate Docker resource settings, should be minimum 8 GB:
+<pre>
+$ docker info | grep "Total Memory"
+or
+$ podman info | grep "memTotal"
+</pre>
+
+Install [Vespa CLI](https://docs.vespa.ai/en/vespa-cli.html):
+<pre>
+$ brew install vespa-cli
+</pre>
+
+For local deployment using docker image:
+<pre data-test="exec">
+$ vespa config set target local
+</pre>
+
+Pull and start the Vespa Docker container:
+<pre data-test="exec">
+$ docker run --detach --name vespa --hostname vespa-container \
+  --publish 127.0.0.1:8080:8080 --publish 127.0.0.1:19071:19071 vespaengine/vespa
+</pre>
+
+Clone this sample app:
+<pre data-test="exec">
+$ vespa clone reverse-image-search myapp && cd myapp
+</pre>
+
+Wait for the configserver to start:
+<pre data-test="exec" data-test-assert-contains="is ready">
+$ vespa status deploy --wait 300 --color never
+</pre>
+
+Deploy the application and wait for services to start:
+<pre data-test="exec">
+$ vespa deploy app --wait 300 --color never
+</pre>
+
+> [!NOTE]
+> The bundled `app/services.xml` requests 2 container nodes and 2 content nodes with explicit
+> `<resources>`. That sizing is intended for Vespa Cloud (the corpus inlines ~75 GB of JPEG bytes
+> for the full 1.28M train split). For a local single-container deploy, edit `app/services.xml`
+> and change both `<nodes count="2">` blocks to `count="1"` and remove the `<resources>` element
+> before running `vespa deploy app`.
+
+## Indexing
+Install the Python dependencies for the feeder and search CLI:
+<pre>
+$ pip install -r script/requirements.txt
+</pre>
+
+Authenticate with HuggingFace (the dataset is gated):
+<pre>
+$ export HF_TOKEN=hf_...
+</pre>
+
+Point the feeder at your Vespa endpoint and feed a small smoke-test subset (500 validation
+images — minutes on CPU):
+<pre>
+$ export RIS_VESPA_URL=http://localhost:8080
+$ python script/feed.py --split validation --limit 500
+</pre>
+
+Other useful invocations:
+<pre>
+$ python script/feed.py --split validation              # full validation split (~50K)
+$ python script/feed.py --split train                   # full train split (~1.28M, GPU strongly recommended)
+$ python script/feed.py --split validation --refeed     # re-feed images already on disk (use after schema changes)
+</pre>
+
+The feeder streams from HuggingFace, resizes each image to max-side 1024 px, embeds with DINOv2,
+base64-encodes the JPEG bytes, and feeds each doc to Vespa with both the bfloat16 embedding and
+the inlined image. It is resumable — IDs whose JPEG is already on disk are skipped unless
+`--refeed` is set.
+
+## Querying
+Run a reverse-image-search query from the command line:
+<pre>
+$ python script/search.py path/to/query.jpg --hits 10 --ranking hybrid
+</pre>
+
+Available rank profiles (mirrored from `script/search.py`):
+
+| `--ranking` | Schema rank profile | What it does |
+|---|---|---|
+| `hybrid` (default) | `closeness` | Binary HNSW first-phase, float cosine rerank on top 100 |
+| `hybrid_strict` | `closeness_hybrid_strict` | Same first-phase, deeper float rerank (top 1000) |
+| `binary` | `closeness_binary` | Binary HNSW only, no rerank — cheapest, smallest memory |
+| `weighted` | `closeness_weighted` | Binary HNSW first-phase, second-phase = α·float + (1−α)·binary |
+
+Both `embedding` and `embedding_binary` are surfaced in the result's `matchfeatures` so you can
+compare the binary closeness, the manually-computed float closeness (`closeness_emb`), and the
+implied bit-agreement ratio for every hit, regardless of which profile was used.
+
+## How it works
+- **Indexing.** Each image is embedded client-side with DINOv2 → L2-normalized 768-d float vector,
+  stored as `tensor<bfloat16>(x[768])` with `paged` attribute (on disk). Vespa derives the binary
+  embedding server-side via `indexing: input embedding | binarize | pack_bits | attribute | index`,
+  giving a `tensor<int8>(x[96])` HNSW-indexed in-memory attribute with Hamming distance.
+- **Retrieval.** Queries run `nearestNeighbor(embedding_binary, q_bin)` for cheap first-phase
+  retrieval. The float `embedding` is read from the paged attribute only for the rerank-count
+  candidates that survive first-phase, so per-query disk I/O is bounded.
+- **Cosine via dot product.** When retrieval is binary-driven, Vespa does **not** populate the
+  built-in `closeness(field, embedding)` cache for candidates, so the schema computes float
+  cosine manually as `sum(query(q) * attribute(embedding))` (both sides L2-normalized) and
+  surfaces it as `closeness_emb` for second-phase ranking and match-features.
+- **Image serving.** `full_image` (base64-encoded JPEG bytes) is fetched on demand via the
+  `with-image` document summary so the index is the single source of truth — there is no
+  separate image store.
+
+## Vespa Cloud notes
+This app is sized for Vespa Cloud out of the box (`app/deployment.xml` pins
+`aws-us-east-1c`, `app/services.xml` requests 2× content nodes at 16 GB / 200 GB). To deploy to
+Vespa Cloud:
+
+1. `vespa auth login`
+2. `vespa config set target cloud`
+3. `vespa config set application <tenant>.reverse-image-search.default`
+4. `vespa auth cert -N`
+5. Copy the generated cert+key from `~/.vespa/<tenant>.reverse-image-search.default/` and point
+   `RIS_VESPA_CERT_PATH` and `RIS_VESPA_KEY_PATH` at them.
+6. `vespa deploy app --wait 600` — note the printed mTLS endpoint URL.
+7. `export RIS_VESPA_URL=https://<endpoint>.vespa-app.cloud` before running the feeder or
+   `script/search.py`.
+
+See the [Vespa Cloud getting-started guide](https://docs.vespa.ai/en/cloud/getting-started.html)
+for full details.
+
+## Cleanup
+Shutdown and remove the local Vespa container:
+<pre data-test="after">
+$ docker rm -f vespa
+</pre>

--- a/reverse-image-search/app/.vespaignore
+++ b/reverse-image-search/app/.vespaignore
@@ -1,0 +1,5 @@
+# This file excludes unnecessary files from the application package. See
+# https://docs.vespa.ai/en/reference/vespaignore.html for more information.
+.DS_Store
+.gitignore
+README.md

--- a/reverse-image-search/app/deployment.xml
+++ b/reverse-image-search/app/deployment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<deployment version="1.0">
+  <prod>
+    <region>aws-us-east-1c</region>
+  </prod>
+</deployment>

--- a/reverse-image-search/app/schemas/image.sd
+++ b/reverse-image-search/app/schemas/image.sd
@@ -1,0 +1,207 @@
+schema image {
+
+    document image {
+
+        field id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+            rank: filter
+        }
+
+        field filename type string {
+            indexing: summary | attribute
+        }
+
+        field path type string {
+            indexing: summary | attribute
+        }
+
+        field split type string {
+            indexing: summary | attribute
+            attribute: fast-search
+            rank: filter
+        }
+
+        field label type int {
+            indexing: summary | attribute
+        }
+
+        field width type int {
+            indexing: summary | attribute
+        }
+
+        field height type int {
+            indexing: summary | attribute
+        }
+
+        field full_image type raw {
+            indexing: summary
+        }
+
+        # bfloat16 embedding stored on disk via `paged`. Used only for second-
+        # phase rerank against candidates retrieved by the binary HNSW, so each
+        # query pages in ~rerank-count vectors from disk — cheap at low QPS.
+        # ~16× less memory than an HNSW-indexed in-memory bfloat16 attribute;
+        # the trade is that float-only retrieval (full scan) is no longer
+        # served at interactive speed, hence no `closeness_float` profile.
+        field embedding type tensor<bfloat16>(x[768]) {
+            indexing: attribute
+            attribute {
+                distance-metric: prenormalized-angular
+                paged
+            }
+        }
+    }
+
+    # Derived binary embedding — Vespa computes this at indexing time from the
+    # already-fed `embedding` field. 768 signed bits packed into 96 int8 slots.
+    # HNSW + hamming makes first-phase retrieval ~16x cheaper than float.
+    field embedding_binary type tensor<int8>(x[96]) {
+        indexing: input embedding | binarize | pack_bits | attribute | index
+        attribute {
+            distance-metric: hamming
+        }
+        index {
+            hnsw {
+                max-links-per-node: 24
+                neighbors-to-explore-at-insert: 200
+            }
+        }
+    }
+
+    # ---------------------------------------------------------------------
+    # Rank profiles. All emit match-features so the UI / eval can see both
+    # the binary (Hamming) closeness AND the float (cosine) closeness for
+    # every hit, regardless of which one drove ranking. That kills the
+    # "0.000 score" surprise for binary-only ranking — the binary closeness
+    # 1/(1+Hamming) for 768 bits is genuinely small (~0.01–0.05 for good
+    # matches), so the UI also derives a more interpretable bit-agreement
+    # ratio = 1 - hamming/768.
+    # ---------------------------------------------------------------------
+
+    # Hybrid: cheap Hamming HNSW first-phase, float cosine rerank on top 100.
+    # Recommended hybrid — fast retrieval, near-float recall.
+    #
+    # Note on `cos_emb`: when retrieval uses nearestNeighbor on
+    # `embedding_binary`, Vespa does NOT pre-compute distance(field, embedding)
+    # for the candidate set, so `closeness(field, embedding)` in this context
+    # returns 0 (it reads from a never-populated cache). We compute the cosine
+    # manually as a dot product — both query and attribute are L2-normalized,
+    # so `sum(q · embedding) ∈ [-1, 1]` directly is the cosine — and convert
+    # to a [0, 1] closeness with `(1 + cos) / 2`. Same trick gives us a
+    # meaningful float score in match-features.
+    rank-profile closeness {
+        inputs {
+            query(q)     tensor<float>(x[768])
+            query(q_bin) tensor<int8>(x[96])
+        }
+
+        function cos_emb() {
+            expression: sum(query(q) * attribute(embedding))
+        }
+        function closeness_emb() {
+            expression: 0.5 * (1 + cos_emb)
+        }
+
+        first-phase {
+            expression: closeness(field, embedding_binary)
+        }
+
+        second-phase {
+            rerank-count: 100
+            expression: closeness_emb
+        }
+
+        match-features {
+            closeness(field, embedding_binary)
+            distance(field, embedding_binary)
+            closeness_emb
+        }
+    }
+
+    # Stricter rerank — same first phase, deeper float rerank pool. Used to
+    # see how recall changes as we let float touch more candidates.
+    rank-profile closeness_hybrid_strict inherits closeness {
+        second-phase {
+            rerank-count: 1000
+            expression: closeness_emb
+        }
+    }
+
+    # Binary-only — first-phase Hamming HNSW, no float rerank. Cheapest and
+    # smallest memory footprint; the article's "what you lose" baseline.
+    # Surfaces the *manually computed* float closeness too so the UI/eval
+    # can see how badly each binary-ranked hit fares under float similarity.
+    rank-profile closeness_binary {
+        inputs {
+            query(q)     tensor<float>(x[768])
+            query(q_bin) tensor<int8>(x[96])
+        }
+
+        function cos_emb() {
+            expression: sum(query(q) * attribute(embedding))
+        }
+        function closeness_emb() {
+            expression: 0.5 * (1 + cos_emb)
+        }
+
+        first-phase {
+            expression: closeness(field, embedding_binary)
+        }
+
+        match-features {
+            closeness(field, embedding_binary)
+            distance(field, embedding_binary)
+            closeness_emb
+        }
+    }
+
+    # Weighted blend — first-phase Hamming HNSW, second-phase weights the
+    # manually computed float closeness against the (real) binary closeness.
+    # `query(alpha)` defaults to 0.5 if not provided.
+    rank-profile closeness_weighted inherits closeness {
+        inputs {
+            query(q)     tensor<float>(x[768])
+            query(q_bin) tensor<int8>(x[96])
+            query(alpha) double
+        }
+
+        second-phase {
+            rerank-count: 100
+            expression: query(alpha) * closeness_emb + (1 - query(alpha)) * closeness(field, embedding_binary)
+        }
+    }
+
+    rank-profile unranked inherits closeness {
+        first-phase {
+            expression: 1
+        }
+    }
+
+    rank-profile random inherits closeness {
+        first-phase {
+            expression: random
+        }
+    }
+
+    document-summary id-only {
+        summary id {}
+        summary path {}
+        summary filename {}
+        summary split {}
+        summary label {}
+        summary width {}
+        summary height {}
+    }
+
+    document-summary with-image {
+        summary id {}
+        summary path {}
+        summary filename {}
+        summary split {}
+        summary label {}
+        summary width {}
+        summary height {}
+        summary full_image {}
+    }
+}

--- a/reverse-image-search/app/search/query-profiles/default.xml
+++ b/reverse-image-search/app/search/query-profiles/default.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<query-profile id="default">
+    <field name="presentation.format.tensors">short-value</field>
+</query-profile>

--- a/reverse-image-search/app/services.xml
+++ b/reverse-image-search/app/services.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container id="default" version="1.0">
+    <document-api/>
+    <search/>
+    <nodes count="2">
+      <resources vcpu="2" memory="8Gb" disk="50Gb"/>
+    </nodes>
+  </container>
+
+  <content id="images" version="1.0">
+    <redundancy>2</redundancy>
+    <documents>
+      <document type="image" mode="index"/>
+    </documents>
+    <nodes count="2">
+      <resources vcpu="4" memory="16Gb" disk="237Gb" storage-type="local"/>
+    </nodes>
+  </content>
+
+</services>

--- a/reverse-image-search/script/feed.py
+++ b/reverse-image-search/script/feed.py
@@ -1,0 +1,210 @@
+"""Feed ImageNet-1k into Vespa.
+
+Streams ILSVRC/imagenet-1k from HuggingFace, saves JPEGs to IMAGES_DIR,
+generates DINOv2 embeddings, and feeds to Vespa with bfloat16 tensors.
+
+Resumable: skips IDs whose image file is already present on disk.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Iterable, Iterator
+
+import torch
+from datasets import load_dataset
+from PIL import Image
+from transformers import AutoImageProcessor, AutoModel
+from vespa.application import Vespa
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("feeder")
+
+VESPA_URL = os.environ["RIS_VESPA_URL"].rstrip("/")
+VESPA_CERT_PATH = os.environ.get("RIS_VESPA_CERT_PATH") or None
+VESPA_KEY_PATH = os.environ.get("RIS_VESPA_KEY_PATH") or None
+IMAGES_DIR = Path(os.environ.get("RIS_IMAGES_DIR", "/data/images"))
+MODEL_NAME = os.environ.get("RIS_MODEL_NAME", "facebook/dinov2-base")
+HF_DATASET = os.environ.get("RIS_HF_DATASET", "ILSVRC/imagenet-1k")
+BATCH_SIZE = int(os.environ.get("RIS_BATCH_SIZE", "32"))
+FEED_CONCURRENCY = int(os.environ.get("RIS_FEED_CONCURRENCY", "8"))
+
+
+def _device() -> str:
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _save_image(img: Image.Image, path: Path, max_side: int = 1024) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = img.convert("RGB")
+    w, h = img.size
+    if max(w, h) > max_side:
+        scale = max_side / max(w, h)
+        img = img.resize((int(w * scale), int(h * scale)), Image.LANCZOS)
+    img.save(path, format="JPEG", quality=88)
+    return img.size
+
+
+def _make_id(split: str, index: int) -> str:
+    return f"{split}-{index:08d}"
+
+
+def _relative_path(split: str, index: int) -> str:
+    shard = index // 1000
+    return f"{split}/{shard:04d}/{_make_id(split, index)}.jpg"
+
+
+def _iter_split(split: str, limit: int | None) -> Iterator[tuple[int, dict]]:
+    log.info("streaming split=%s limit=%s", split, limit)
+    ds = load_dataset(HF_DATASET, split=split, streaming=True)
+    for i, ex in enumerate(ds):
+        if limit is not None and i >= limit:
+            break
+        yield i, ex
+
+
+def _batched(iterable: Iterable, size: int) -> Iterator[list]:
+    batch: list = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def _iter_docs_for_feed(docs: list[dict]) -> Iterator[dict]:
+    for d in docs:
+        yield {
+            "id": d["id"],
+            "fields": {
+                "id": d["id"],
+                "filename": d["filename"],
+                "path": d["path"],
+                "split": d["split"],
+                "label": d["label"],
+                "width": d["width"],
+                "height": d["height"],
+                "embedding": {"values": d["embedding"]},
+                "full_image": d["full_image"],
+            },
+        }
+
+
+def run(split: str, limit: int | None, refeed: bool = False) -> None:
+    device = _device()
+    log.info("loading %s on %s", MODEL_NAME, device)
+    processor = AutoImageProcessor.from_pretrained(MODEL_NAME)
+    model = AutoModel.from_pretrained(MODEL_NAME).to(device).eval()
+
+    vespa_kwargs: dict = {"url": VESPA_URL}
+    if VESPA_CERT_PATH and VESPA_KEY_PATH:
+        vespa_kwargs["cert"] = VESPA_CERT_PATH
+        vespa_kwargs["key"] = VESPA_KEY_PATH
+    app = Vespa(**vespa_kwargs)
+
+    total_ok = 0
+    total_fail = 0
+    total_skip = 0
+
+    def callback(response, doc_id):
+        nonlocal total_ok, total_fail
+        if response.is_successful():
+            total_ok += 1
+        else:
+            total_fail += 1
+            log.warning("feed fail id=%s status=%s body=%s",
+                        doc_id, response.get_status_code(), response.get_json())
+
+    with torch.inference_mode():
+        for batch in _batched(_iter_split(split, limit), BATCH_SIZE):
+            pil_images: list[Image.Image] = []
+            pending: list[dict] = []
+
+            for i, ex in batch:
+                doc_id = _make_id(split, i)
+                rel = _relative_path(split, i)
+                abs_path = IMAGES_DIR / rel
+                img = ex["image"]
+                if not isinstance(img, Image.Image):
+                    continue
+                # Save if missing; otherwise skip unless --refeed.
+                if abs_path.exists() and not refeed:
+                    total_skip += 1
+                    continue
+                try:
+                    if not abs_path.exists():
+                        w, h = _save_image(img, abs_path)
+                    else:
+                        with Image.open(abs_path) as existing:
+                            w, h = existing.size
+                except Exception as e:
+                    log.warning("save failed id=%s: %s", doc_id, e)
+                    continue
+                jpeg_bytes = abs_path.read_bytes()
+                pil_images.append(Image.open(abs_path).convert("RGB"))
+                pending.append({
+                    "id": doc_id,
+                    "filename": f"{doc_id}.jpg",
+                    "path": rel,
+                    "split": split,
+                    "label": int(ex.get("label", -1) or -1),
+                    "width": w,
+                    "height": h,
+                    "full_image": base64.b64encode(jpeg_bytes).decode("ascii"),
+                })
+
+            if not pending:
+                continue
+
+            inputs = processor(images=pil_images, return_tensors="pt").to(device)
+            output = model(**inputs)
+            cls = output.last_hidden_state[:, 0]
+            cls = torch.nn.functional.normalize(cls, dim=-1)
+            embs = cls.to("cpu", dtype=torch.float32).numpy()
+
+            for rec, emb in zip(pending, embs):
+                rec["embedding"] = emb.tolist()
+
+            # feed_iterable (sync, threaded) is used instead of feed_async_iterable
+            # because pyvespa 1.1.2's async feed path does not propagate mTLS certs
+            # to its internal httpr client — every request gets a 401 from Vespa Cloud.
+            app.feed_iterable(
+                iter=_iter_docs_for_feed(pending),
+                schema="image",
+                callback=callback,
+                max_queue_size=FEED_CONCURRENCY * 8,
+                max_workers=FEED_CONCURRENCY,
+                max_connections=FEED_CONCURRENCY,
+            )
+            log.info("progress split=%s ok=%d fail=%d skip=%d",
+                     split, total_ok, total_fail, total_skip)
+
+    log.info("done split=%s ok=%d fail=%d skip=%d",
+             split, total_ok, total_fail, total_skip)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split", default="train", choices=["train", "validation", "test"])
+    parser.add_argument("--limit", type=int, default=None, help="cap number of images (for testing)")
+    parser.add_argument(
+        "--refeed",
+        action="store_true",
+        help="Re-feed images that are already on disk (use after a schema change).",
+    )
+    args = parser.parse_args()
+    IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+    run(args.split, args.limit, refeed=args.refeed)
+
+
+if __name__ == "__main__":
+    main()

--- a/reverse-image-search/script/requirements.txt
+++ b/reverse-image-search/script/requirements.txt
@@ -1,0 +1,10 @@
+torch>=2.5.0
+transformers>=4.46.0
+torchvision>=0.20.0
+pillow>=11.0.0
+numpy>=2.0.0
+datasets>=3.0.0
+pyvespa>=1.1.2
+huggingface_hub>=0.26.0
+hf-transfer>=0.1.8
+httpx>=0.28.0

--- a/reverse-image-search/script/search.py
+++ b/reverse-image-search/script/search.py
@@ -1,0 +1,144 @@
+"""Run a reverse-image-search query against a deployed Vespa application.
+
+Loads the same DINOv2 model used by the feeder, embeds the input image, packs
+the binary version, and runs a `nearestNeighbor(embedding_binary, q_bin)`
+query with the `closeness` rank profile — same path the demo's backend uses.
+
+Environment
+-----------
+    RIS_VESPA_URL        Vespa endpoint (e.g. http://localhost:8080 for local
+                         Docker, or the mTLS URL printed by `vespa deploy` for
+                         Vespa Cloud). Required.
+    RIS_VESPA_CERT_PATH  Optional. Path to data-plane public cert (Vespa Cloud).
+    RIS_VESPA_KEY_PATH   Optional. Path to data-plane private key (Vespa Cloud).
+    RIS_MODEL_NAME       Default: facebook/dinov2-base.
+    RIS_DEVICE           Default: auto (cuda → mps → cpu).
+
+Usage
+-----
+    python search.py path/to/query.jpg --hits 10 --ranking hybrid
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import AutoImageProcessor, AutoModel
+from vespa.application import Vespa
+
+
+_RANKING_PROFILES = {
+    "hybrid":         "closeness",                # binary HNSW first-phase + float rerank top 100
+    "hybrid_strict":  "closeness_hybrid_strict",  # same, rerank top 1000
+    "binary":         "closeness_binary",         # binary HNSW only, no rerank
+    "weighted":       "closeness_weighted",       # binary HNSW first-phase + α·float + (1−α)·binary rerank
+}
+
+
+def _device(requested: str) -> str:
+    if requested != "auto":
+        return requested
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _embed(image_path: Path, model_name: str, device: str) -> np.ndarray:
+    processor = AutoImageProcessor.from_pretrained(model_name)
+    model = AutoModel.from_pretrained(model_name).to(device).eval()
+    img = Image.open(image_path).convert("RGB")
+    with torch.inference_mode():
+        batch = processor(images=[img], return_tensors="pt").to(device)
+        out = model(**batch)
+        cls = out.last_hidden_state[:, 0]
+        cls = torch.nn.functional.normalize(cls, dim=-1)
+    return cls.detach().to("cpu", dtype=torch.float32).numpy()[0]
+
+
+def _pack_binary(emb: np.ndarray) -> np.ndarray:
+    """Sign-bit pack 768 floats into 96 int8s — matches the schema's
+    `binarize | pack_bits` indexing pipeline so the query tensor is
+    bit-aligned with the indexed `embedding_binary` field."""
+    bits = (emb > 0).astype(np.uint8)
+    return np.packbits(bits).view(np.int8)
+
+
+def _search(
+    app: Vespa,
+    embedding: np.ndarray,
+    hits: int,
+    target_hits: int,
+    ranking: str,
+    alpha: float | None,
+) -> dict:
+    profile = _RANKING_PROFILES[ranking]
+    binary_q = _pack_binary(embedding)
+    body = {
+        "yql": (
+            f"select * from image where "
+            f"{{targetHits:{target_hits}}}nearestNeighbor(embedding_binary, q_bin)"
+        ),
+        "input.query(q)":     embedding.astype(np.float32).tolist(),
+        "input.query(q_bin)": binary_q.astype(int).tolist(),
+        "ranking.profile":    profile,
+        "hits":               hits,
+        "presentation.summary": "id-only",
+    }
+    if ranking == "weighted" and alpha is not None:
+        body["input.query(alpha)"] = float(alpha)
+    response = app.query(body=body)
+    if not response.is_successful():
+        raise RuntimeError(f"Vespa query failed: {response.get_json()}")
+    return response.json
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("image", type=Path, help="Path to the query image")
+    p.add_argument("--hits", type=int, default=10)
+    p.add_argument("--target-hits", type=int, default=200,
+                   help="targetHits for nearestNeighbor — affects HNSW exploration depth")
+    p.add_argument("--ranking", choices=list(_RANKING_PROFILES), default="hybrid")
+    p.add_argument("--alpha", type=float, default=0.7,
+                   help="weight on float closeness in the `weighted` profile (1-α on binary)")
+    args = p.parse_args()
+
+    url = os.environ["RIS_VESPA_URL"].rstrip("/")
+    cert = os.environ.get("RIS_VESPA_CERT_PATH") or None
+    key = os.environ.get("RIS_VESPA_KEY_PATH") or None
+    kwargs: dict = {"url": url}
+    if cert and key:
+        kwargs["cert"] = cert
+        kwargs["key"] = key
+    app = Vespa(**kwargs)
+
+    model_name = os.environ.get("RIS_MODEL_NAME", "facebook/dinov2-base")
+    device = _device(os.environ.get("RIS_DEVICE", "auto"))
+    embedding = _embed(args.image, model_name, device)
+
+    payload = _search(app, embedding, args.hits, args.target_hits, args.ranking, args.alpha)
+    children = (payload.get("root") or {}).get("children") or []
+    for hit in children:
+        fields = hit.get("fields") or {}
+        mf = fields.get("matchfeatures") or {}
+        print(json.dumps({
+            "id":               fields.get("id"),
+            "filename":         fields.get("filename"),
+            "split":            fields.get("split"),
+            "label":            fields.get("label"),
+            "score":            hit.get("relevance"),
+            "binary_closeness": mf.get("closeness(field,embedding_binary)"),
+            "float_closeness":  mf.get("closeness_emb"),
+        }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new sample app demonstrating reverse image search with Vespa using DINOv2 embeddings.

- reverse-image-search/app/ — Vespa application package with an image schema that stores 768-dim DINOv2 embeddings as a tensor<bfloat16> and ranks matches by cosine similarity (HNSW ANN).
- reverse-image-search/script/feed.py — feeds a subset of ImageNet-1k from Hugging Face: extracts DINOv2 features and pushes documents to Vespa.
- reverse-image-search/script/search.py — encodes a query image with DINOv2 and runs a nearestNeighbor query against the deployed app.
- reverse-image-search/README.md — quickstart covering local Docker and Vespa Cloud deployment, feeding, and querying.

Test plan

- vespa deploy the app package against a local Vespa container
- Run python script/feed.py against a small image subset and verify documents appear via vespa visit
- Run python script/search.py <image> and confirm top-K results are visually similar
- Repeat against a Vespa Cloud dev deployment
- Verify README links render correctly on GitHub