### PR TITLE
using built in averageFieldLength rank feature for BBM25

### DIFF
--- a/examples/bayesian_bm25/README.md
+++ b/examples/bayesian_bm25/README.md
@@ -147,7 +147,6 @@ Content-Type: application/json
   "ranking.profile": "bayesian_bm25_calibrated",
   "ranking.features.query(alpha)": 1.5,
   "ranking.features.query(beta)": 2.0,
-  "ranking.features.query(avg_field_len)": 35.0,
   "ranking.features.query(base_rate)": 0.02
 }
 ```
@@ -156,7 +155,6 @@ Content-Type: application/json
 
 - Provide a script to compute the base rate. This could simply run queries (like in paper at algorithm 4.4.7) or could be computed before every query from a [Searcher](https://docs.vespa.ai/en/applications/searchers.html) probably overkill. Having actual labels to do it would be even better (and more complicated).
 - The TF prior should be computed as the average prior for each term in the query, instead of computing a single prior for average TFs. More complex to define in Vespa. Current implementation is OK, unless we have many terms.
-- Vespa should expose average field length as a rank feature and we should reuse that.
 - Ideally, we should have a way (scripts) to tune the hardcoded values when we compute priors.
 - Using the [weakAnd](https://docs.vespa.ai/en/ranking/wand.html#weakand) in Vespa ignores the TF/length priors while pruning. This shouldn't make a big difference for most queries - increase `targetHits` to overfetch if tail end quality is a problem.
 - When using BBM25 in hybrid search, remember that most vector scores aren't probabilities, even if they are in [0,1]. Comparing this to other methods ([atan](https://docs.vespa.ai/en/learn/tutorials/hybrid-search.html#hybrid-ranking), [linear, RRF](https://docs.vespa.ai/en/ranking/phased-ranking.html#cross-hit-normalization-including-reciprocal-rank-fusion) - comparison between them can be found [in this blog post](https://blog.vespa.ai/embedding-tradeoffs-quantified)) will be interesting.

--- a/examples/bayesian_bm25/app/schemas/doc.sd
+++ b/examples/bayesian_bm25/app/schemas/doc.sd
@@ -62,17 +62,11 @@ schema doc {
     #
     # TF prior uses foreach to average per-term occurrences, avoiding the bias
     # of aggregate matchCount which inflates the prior for longer queries.
-    #
-    # Additional parameter:
-    #   avg_field_len -- average field length in words. Vespa computes this
-    #                    internally for BM25 but does not expose it as a rank
-    #                    feature, so it must be supplied. Default 35.0 - this sample corpus
     # ---------------------------------------------------------------------------
     rank-profile bayesian_bm25 {
         inputs {
             query(alpha)         double: 1.0
             query(beta)          double: 3.0
-            query(avg_field_len) double: 35.0
         }
 
         function raw_bm25() {
@@ -96,7 +90,7 @@ schema doc {
         # Eq. 26: P_norm(n) = 0.3 + 0.6 * (1 - min(1, |n - 0.5| * 2))
         #         where n = fieldLength / avgFieldLen
         function fieldnorm_prior() {
-            expression: 0.3 + 0.6 * (1 - min(1, fabs(fieldLength(body) / query(avg_field_len) - 0.5) * 2))
+            expression: 0.3 + 0.6 * (1 - min(1, fabs(fieldLength(body) / averageFieldLength(body) - 0.5) * 2))
         }
 
         # Eq. 27: P_prior = clamp(0.7 * P_tf + 0.3 * P_norm, 0.1, 0.9)
@@ -127,6 +121,7 @@ schema doc {
             posterior
             fieldLength(body)
             matchCount(body)
+            averageFieldLength(body)
         }
     }
 
@@ -170,6 +165,7 @@ schema doc {
             posterior
             calibrated_posterior
             fieldLength(body)
+            averageFieldLength(body)
             matchCount(body)
         }
     }
@@ -217,6 +213,7 @@ schema doc {
             logit_tf_prior
             logit_fieldnorm_prior
             fieldLength(body)
+            averageFieldLength(body)
         }
     }
 
@@ -254,6 +251,7 @@ schema doc {
             logit_tf_prior
             logit_fieldnorm_prior
             fieldLength(body)
+            averageFieldLength(body)
         }
     }
 }


### PR DESCRIPTION
Previously, this was a query-time parameter. Since https://github.com/vespa-engine/vespa/pull/36599, we have `averageFieldLength` dynamically computed in Vespa.

/cc @dainiusjocas Not sure if you tried this yet, but here's an example.