### PR TITLE
BM25F-like cross-field search

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,11 @@
 
 # Vespa Code And Operational Examples
 
+### BM25F-inspired cross-field ranking
+[![logo](/assets/vespa-logomark-tiny.png) BM25F-inspired cross-field search](bm25f)
+demonstrates cross-field ranking over title and body by composing BM25F-inspired ranking expressions from per-term and per-field ranking features.
+
+
 ### Vespa grouping and facets for organizing results
 [![logo](/assets/vespa-logomark-tiny.png) Grouping Results](part-purchases-demo)
 demonstrates Vespa grouping and faceting for query time result analytics.

--- a/examples/bm25f/README.md
+++ b/examples/bm25f/README.md
@@ -1,0 +1,49 @@
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
+# BM25F-inspired cross-field search
+
+Minimal Vespa application implementing BM25F-*inspired* cross-field ranking over `title` and `body` with ranking expressions. "Inspired" rather than BM25F proper, because the document frequency is the term-level estimate for the fieldset — the *sum* of per-field dfs, an upper bound on the document-level df canonical BM25F specifies (docs containing the term in several fields are double-counted).
+
+NOTE: This is only correct for fieldset queries, and the sample query's `text()` retrieves via weakAnd, so with a large corpus and low `targetHits` not every matching document is surfaced for scoring.
+
+The saturation/idf structure — per-term weighted tf summed across fields *before* saturation, one idf per term — is the BM25F part. Built from these ingredients:
+
+- `fieldTermMatch(field, n).occurrences` — term frequency of query term `n` in `field` (per-document; `n` is the global query-term index)
+- `fieldLength(field)` and `averageFieldLength(field)` — per-field length normalization
+- `queryTermDocumentFrequency(field)` — `tensor(term{})` of the document frequency BM25 would use per query term
+- `num_docs_indexed` — corpus size for the IDF
+
+The BM25F score (`rank-profile bm25f`, k1 = 1.2, b = 0.75 for both fields, field weights: title = 2.0, body = 1.0):
+
+```
+wtf(t)  = sum_f  weight_f * tf(t, f) / (1 - b_f + b_f * fieldLength(f) / averageFieldLength(f))
+df(t)   = queryTermDocumentFrequency(title){term: t}         # term-level (same tensor in every field for fieldset terms)
+idf(t)  = log(1 + (num_docs_indexed - df(t) + 0.5) / (df(t) + 0.5))
+bm25f   = sum_t  idf(t) * wtf(t) / (k1 + wtf(t))
+```
+
+`weighted_tf` is assembled as a literal `tensor(term{})` whose cells call the parameterized function `term_wtf(n)` for term indexes 0..7. Tensor literals are fixed at config time, so this is a cap, not iteration: queries with more than 8 terms have the extra terms silently ignored (raise the cap by adding cells). Unused labels contribute 0 and drop out in the join with `idf`, so any query with up to 8 terms works unchanged — verified with a 3-term query (adding `engine`: doc 1 scores 0.62942 → 1.52058, matching hand computation). Everything downstream (df, idf, score) is generic tensor math.
+
+## Deploy and feed
+
+From the `examples/bm25f` directory:
+
+```bash
+vespa config set target local
+vespa deploy --wait 300 app
+vespa feed dataset/documents.jsonl
+```
+
+## Query
+
+```bash
+vespa query \
+  'yql=select * from bm25f where default contains text("vespa ranking")' \
+  'ranking=bm25f'
+```
+
+## Document frequency semantics with fieldsets
+
+When a query term searches multiple fields through a fieldset, the query planner gives every term-field the **combined** document frequency estimate — the sum of the per-field dfs — and that is what both `bm25(field)` and `queryTermDocumentFrequency(field)` see. With fieldset queries, `queryTermDocumentFrequency(title)` and `(body)` return identical tensors, and `document_frequency` simply reads one of them — no cross-field combination is needed.
+
+The summed df is an upper bound on the document-level df that canonical BM25F wants (a doc containing the term in both fields is counted twice), and is closer to it than any per-field df. To get true per-field dfs, query each field with separate terms — at the cost of different `term{}` labels per field.

--- a/examples/bm25f/app/schemas/bm25f.sd
+++ b/examples/bm25f/app/schemas/bm25f.sd
@@ -1,0 +1,119 @@
+schema bm25f {
+    document bm25f {
+        field title type string {
+            indexing: summary | index
+            index: enable-bm25
+        }
+
+        field body type string {
+            indexing: summary | index
+            index: enable-bm25
+        }
+    }
+
+    fieldset default {
+        fields: title, body
+    }
+
+    # BM25F-inspired cross-field ranking (see README for why "inspired":
+    # summed term-level df instead of document-level df, N-term cap,
+    # fieldset queries only).
+    rank-profile bm25f {
+        function k1() {
+            expression: 1.2
+        }
+
+        function b_title() {
+            expression: 0.75
+        }
+
+        function b_body() {
+            expression: 0.75
+        }
+
+        function weight_title() {
+            expression: 2.0
+        }
+
+        function weight_body() {
+            expression: 1.0
+        }
+
+        function len_norm_title() {
+            expression: 1 - b_title + b_title * fieldLength(title) / averageFieldLength(title)
+        }
+
+        function len_norm_body() {
+            expression: 1 - b_body + b_body * fieldLength(body) / averageFieldLength(body)
+        }
+
+        # Weighted, length-normalized term frequency for query term n, summed
+        # across fields (the core of BM25F). fieldTermMatch(field, n) uses the
+        # global query-term index — the same index space as the term{} labels
+        # of queryTermDocumentFrequency(field) — and yields 0 occurrences for
+        # nonexistent terms.
+        function term_wtf(n) {
+            expression: weight_title * fieldTermMatch(title, n).occurrences / len_norm_title + weight_body * fieldTermMatch(body, n).occurrences / len_norm_body
+        }
+
+        # Tensor literals are fixed at config time, so this supports up to 8
+        # query terms; terms beyond that are silently ignored. Labels for
+        # nonexistent terms get value 0 and drop out of the score in the join
+        # with idf (which only has cells for real terms).
+        function weighted_tf() {
+            expression {
+                tensor(term{}):{
+                    "0": term_wtf(0),
+                    "1": term_wtf(1),
+                    "2": term_wtf(2),
+                    "3": term_wtf(3),
+                    "4": term_wtf(4),
+                    "5": term_wtf(5),
+                    "6": term_wtf(6),
+                    "7": term_wtf(7)
+                }
+            }
+        }
+
+        # This profile requires fieldset queries (each term searching both
+        # fields), and for those the df is term-level: every field reports
+        # the same tensor, so reading it from either field is equivalent.
+        function document_frequency() {
+            expression: queryTermDocumentFrequency(title)
+        }
+
+        function idf() {
+            expression: log(1 + (num_docs_indexed - document_frequency + 0.5) / (document_frequency + 0.5))
+        }
+
+        function bm25f_score() {
+            expression: reduce(idf * weighted_tf / (k1 + weighted_tf), sum, term)
+        }
+
+        first-phase {
+            expression: bm25f_score
+        }
+
+        match-features {
+            queryTermDocumentFrequency(title)
+            queryTermDocumentFrequency(body)
+            rankingExpression(document_frequency)
+            rankingExpression(idf)
+            rankingExpression(weighted_tf)
+            rankingExpression(len_norm_title)
+            rankingExpression(len_norm_body)
+            rankingExpression(bm25f_score)
+            fieldLength(title)
+            fieldLength(body)
+            averageFieldLength(title)
+            averageFieldLength(body)
+            num_docs_indexed
+            fieldTermMatch(title, 0).occurrences
+            fieldTermMatch(title, 1).occurrences
+            fieldTermMatch(body, 0).occurrences
+            fieldTermMatch(body, 1).occurrences
+            bm25(title)
+            bm25(body)
+        }
+    }
+}

--- a/examples/bm25f/app/services.xml
+++ b/examples/bm25f/app/services.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<services version="1.0">
+  <container id="default" version="1.0">
+    <search/>
+    <document-api/>
+  </container>
+
+  <content id="bm25f" version="1.0">
+    <redundancy>1</redundancy>
+    <documents>
+      <document type="bm25f" mode="index"/>
+    </documents>
+    <nodes>
+      <node distribution-key="0" hostalias="node1"/>
+    </nodes>
+  </content>
+</services>

--- a/examples/bm25f/dataset/documents.jsonl
+++ b/examples/bm25f/dataset/documents.jsonl
@@ -1,0 +1,6 @@
+{"put": "id:bm25f:bm25f::1", "fields": {"title": "vespa ranking engine", "body": "vespa is great for ranking many documents"}}
+{"put": "id:bm25f:bm25f::2", "fields": {"title": "vespa quick guide", "body": "get going with search"}}
+{"put": "id:bm25f:bm25f::3", "fields": {"title": "advanced vespa", "body": "tuning and profiles"}}
+{"put": "id:bm25f:bm25f::4", "fields": {"title": "cooking pasta", "body": "boil water then add pasta near vespa in Trondheim"}}
+{"put": "id:bm25f:bm25f::5", "fields": {"title": "gardening tips", "body": "plant flowers in spring for better ranking"}}
+{"put": "id:bm25f:bm25f::6", "fields": {"title": "unrelated things", "body": "nothing to see here"}}


### PR DESCRIPTION
This is an example of implementing cross-field search with BM25F. It's not exactly that (per-term DFs aren't truly global), but it should work well in practice for cross-field search. Most search engines don't maintain true per-term DFs, and computing them at query-time is expensive.

**NOTE**: this PR depends on https://github.com/vespa-engine/vespa/pull/37373 - so if we change something there (e.g., the name of the rank feature), this one will need to be updated as well. I'm making this a draft because of it. Once we have the feature, we can merge this one.