### PR TITLE
Lucene linguistics: hyphenationCompoundWord example

### DIFF
--- a/examples/lucene-linguistics/hyphenation-compound-word/.gitignore
+++ b/examples/lucene-linguistics/hyphenation-compound-word/.gitignore
@@ -1,0 +1,2 @@
+src/main/application/lucene-linguistics/dictionary-de.txt
+src/main/application/lucene-linguistics/de_DR.xml

--- a/examples/lucene-linguistics/hyphenation-compound-word/README.md
+++ b/examples/lucene-linguistics/hyphenation-compound-word/README.md
@@ -1,0 +1,102 @@
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
+# German compound splitting with Lucene Linguistics
+
+This sample uses Lucene's `hyphenationCompoundWord` token filter to split
+German compound words. The original word and dictionary-recognized parts are
+indexed as alternatives at the same position. For example,
+`Donaudampfschiff` produces `donaudampfschiff`, `donau`, `dampf`, and
+`schiff`.
+
+The analyzer is based on the configuration recommended by the
+[German Decompounder project](https://github.com/uschindler/german-decompounder):
+a standard tokenizer followed by lowercase, hyphenation-based decompounding,
+German normalization, and German light stemming.
+
+## Download the linguistic resources
+
+The German Decompounder dictionary is LGPL-3.0-or-later, and the hyphenation
+patterns use the LaTeX Project Public License. They are therefore downloaded
+instead of being included in this Apache-2.0-licensed sample. See the
+[upstream notice](https://github.com/uschindler/german-decompounder/blob/master/NOTICE.txt)
+for details.
+
+Run the downloader before building:
+
+```bash
+./download-resources.sh
+```
+
+The script makes a shallow clone of the upstream repository and copies
+`dictionary-de.txt` and the Lucene-compatible `de_DR.xml` under
+`src/main/application/lucene-linguistics/`, the directory configured by
+`configDir` in `services.xml`.
+
+## Build and deploy
+
+This sample requires Java 17, Maven 3.6 or newer, Git, the Vespa CLI, and a
+running Vespa deployment selected as the CLI target.
+
+```bash
+mvn clean package
+vespa deploy --wait 300 target/application
+vespa feed documents.jsonl
+```
+
+The deployable application is `target/application`, not
+`src/main/application`, because the Maven build adds the custom component
+bundle under `target/application/components`.
+
+## Query compound parts
+
+Query for `dampf`, which is a part of two sample compounds:
+
+```bash
+vespa query \
+  'yql=select * from doc where title contains "dampf"' \
+  'model.locale=de' \
+  'presentation.summary=debug-text-tokens'
+```
+
+The result contains `id:test:doc::donau` (`Donaudampfschiff`) and
+`id:test:doc::dampf` (`Dampfschiff`). The `title_tokens` summary shows the
+full indexed word and its emitted parts. `model.locale=de` selects the German
+analyzer for query text, while the documents set their indexing language with
+the `language` field.
+
+## Why this sample builds an application bundle
+
+Lucene's hyphenation parser uses the Java XML packages `javax.xml.parsers`,
+`org.xml.sax`, and `org.xml.sax.helpers`. These uses originate in an embedded
+dependency, so automatic OSGi bundle analysis does not discover them. If
+`LuceneLinguistics` is loaded from a bundle without those imports, Vespa's
+container component graph fails to start with an error such as:
+
+```text
+NoClassDefFoundError: org/xml/sax/InputSource
+```
+
+No Vespa platform modification is needed. Like the
+[custom analyzer phonetic sample](../custom-analyzer-phonetic/), this
+application compiles `lucene-linguistics` into an application-owned bundle.
+The bundle plugin configuration in `pom.xml` adds the exact missing imports:
+
+```xml
+<Import-Package>javax.xml.parsers,org.xml.sax,org.xml.sax.helpers</Import-Package>
+```
+
+The component declaration in `services.xml` deliberately names that bundle:
+
+```xml
+<component id="linguistics"
+           class="com.yahoo.language.lucene.LuceneLinguistics"
+           bundle="lucene-linguistics-hyphenation-compound-word">
+```
+
+Using `bundle="lucene-linguistics"` here would load the installed platform
+bundle instead and bypass the imports added by this application.
+
+Finally, the schema uses `stemming: multiple`. The decompounder emits the full
+compound and its parts at the same token position; this setting preserves all
+of those alternatives in the index. It's the same problem/solutions as with
+[ngrams](https://docs.vespa.ai/en/linguistics/lucene-linguistics.html#indexing-all-stemmed-words).

--- a/examples/lucene-linguistics/hyphenation-compound-word/documents.jsonl
+++ b/examples/lucene-linguistics/hyphenation-compound-word/documents.jsonl
@@ -1,0 +1,4 @@
+{"put":"id:test:doc::donau","fields":{"language":"de","title":"Donaudampfschiff"}}
+{"put":"id:test:doc::dampf","fields":{"language":"de","title":"Dampfschiff"}}
+{"put":"id:test:doc::sonne","fields":{"language":"de","title":"Sonnenblume"}}
+{"put":"id:test:doc::control","fields":{"language":"de","title":"Unverbundene Begriffe"}}

--- a/examples/lucene-linguistics/hyphenation-compound-word/download-resources.sh
+++ b/examples/lucene-linguistics/hyphenation-compound-word/download-resources.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set -euo pipefail
+
+readonly script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly resource_dir="${script_dir}/src/main/application/lucene-linguistics"
+readonly temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/german-decompounder.XXXXXX")"
+trap 'rm -rf "${temporary_dir}"' EXIT
+
+mkdir -p "${resource_dir}"
+git clone --depth 1 https://github.com/uschindler/german-decompounder.git "${temporary_dir}/repository"
+cp "${temporary_dir}/repository/dictionary-de.txt" "${resource_dir}/"
+cp "${temporary_dir}/repository/de_DR.xml" "${resource_dir}/"

--- a/examples/lucene-linguistics/hyphenation-compound-word/pom.xml
+++ b/examples/lucene-linguistics/hyphenation-compound-word/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ai.vespa</groupId>
+  <artifactId>lucene-linguistics-hyphenation-compound-word</artifactId>
+  <version>0.0.1</version>
+  <packaging>container-plugin</packaging>
+
+  <parent>
+    <groupId>com.yahoo.vespa</groupId>
+    <artifactId>cloud-tenant-base</artifactId>
+    <version>[8,9)</version>
+    <relativePath/>
+  </parent>
+
+  <properties>
+    <bundle-plugin.failOnWarnings>false</bundle-plugin.failOnWarnings>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <test.hide>true</test.hide>
+  </properties>
+
+  <dependencies>
+    <!-- Compile scope embeds LuceneLinguistics and Lucene in this application's bundle. -->
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>lucene-linguistics</artifactId>
+      <version>${vespaversion}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>linguistics</artifactId>
+      <version>${vespaversion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>application</artifactId>
+      <version>${vespaversion}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.yahoo.vespa</groupId>
+        <artifactId>bundle-plugin</artifactId>
+        <version>${vespaversion}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <failOnWarnings>false</failOnWarnings>
+          <!-- Lucene's hyphenation parser uses these Java XML APIs. -->
+          <Import-Package>javax.xml.parsers,org.xml.sax,org.xml.sax.helpers</Import-Package>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/.vespaignore
+++ b/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/.vespaignore
@@ -1,0 +1,5 @@
+# This file excludes unnecessary files from the application package. See
+# https://docs.vespa.ai/en/reference/vespaignore.html for more information.
+.DS_Store
+.gitignore
+README.md

--- a/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/schemas/doc.sd
+++ b/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/schemas/doc.sd
@@ -1,0 +1,34 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+schema doc {
+
+    document doc {
+        field language type string {
+            indexing: set_language | summary
+        }
+
+        field title type string {
+            indexing: summary | index
+            index: enable-bm25
+            linguistics {
+                profile: de_compound
+            }
+            # Preserve the compound and all parts emitted at the same position.
+            stemming: multiple
+        }
+    }
+
+    fieldset default {
+        fields: title
+    }
+
+    document-summary debug-text-tokens {
+        summary documentid {}
+        summary language {}
+        summary title {}
+        summary title_tokens {
+            source: title
+            tokens
+        }
+        from-disk
+    }
+}

--- a/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/services.xml
+++ b/examples/lucene-linguistics/hyphenation-compound-word/src/main/application/services.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+  <container id="container" version="1.0">
+    <components>
+      <component id="linguistics"
+                 class="com.yahoo.language.lucene.LuceneLinguistics"
+                 bundle="lucene-linguistics-hyphenation-compound-word">
+        <config name="com.yahoo.language.lucene.lucene-analysis">
+          <configDir>lucene-linguistics</configDir>
+          <analysis>
+            <item key="profile=de_compound;language=de">
+              <tokenizer>
+                <name>standard</name>
+              </tokenizer>
+              <tokenFilters>
+                <item>
+                  <name>lowercase</name>
+                </item>
+                <item>
+                  <name>hyphenationCompoundWord</name>
+                  <conf>
+                    <item key="hyphenator">de_DR.xml</item>
+                    <item key="dictionary">dictionary-de.txt</item>
+                    <item key="onlyLongestMatch">true</item>
+                    <item key="minSubwordSize">4</item>
+                  </conf>
+                </item>
+                <item>
+                  <name>germanNormalization</name>
+                </item>
+                <item>
+                  <name>germanLightStem</name>
+                </item>
+              </tokenFilters>
+            </item>
+          </analysis>
+        </config>
+      </component>
+    </components>
+    <document-processing/>
+    <document-api/>
+    <search/>
+  </container>
+
+  <content id="content" version="1.0">
+    <min-redundancy>1</min-redundancy>
+    <documents>
+      <document type="doc" mode="index"/>
+      <document-processing cluster="container"/>
+    </documents>
+  </content>
+</services>


### PR DESCRIPTION
Makes https://github.com/uschindler/german-decompounder work with Vespa. But it's a generic solution for other `hyphenationCompoundWord` uses.

The main problem is that we need to bundle some dependencies for parsing XML.