### PR TITLE
fix: HF download and service.xml

### DIFF
--- a/news/app-2-feed-and-query/services.xml
+++ b/news/app-2-feed-and-query/services.xml
@@ -5,9 +5,7 @@
   <container id='default' version='1.0'>
     <search></search>
     <document-api></document-api>
-    <nodes>
-      <node hostalias='node1'></node>
-    </nodes>
+    <nodes count="1" />
   </container>
 
   <content id='mind' version='1.0'>
@@ -15,9 +13,7 @@
     <documents>
       <document type='news' mode="index"/>
     </documents>
-    <nodes>
-      <node hostalias="node1" distribution-key="0" />
-    </nodes>
+    <nodes count="1" />
   </content>
 
 </services>

--- a/news/bin/download-mind.sh
+++ b/news/bin/download-mind.sh
@@ -5,23 +5,28 @@ DIR="mind"
 TRAIN_DIR="$DIR/train"
 DEV_DIR="$DIR/dev"
 
+if [ -z "$HF_TOKEN" ]; then
+  echo "HF_TOKEN not set. Get a READ token from https://huggingface.co/settings/tokens"
+  echo "Then: export HF_TOKEN=hf_..."
+  exit 1
+fi
+
+HF_HEADER="Authorization: Bearer $HF_TOKEN"
+
 mkdir -p $TRAIN_DIR
 mkdir -p $DEV_DIR
 
-if [ "$DATASET" = "demo" ]
-then
-  curl -L -o $DIR/train.zip  https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_train.zip?download=true
-  curl -L -o $DIR/dev.zip    https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_dev.zip?download=true
+if [ "$DATASET" = "demo" ]; then
+  curl -L -H "$HF_HEADER" -o $DIR/train.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_train.zip?download=true"
+  curl -L -H "$HF_HEADER" -o $DIR/dev.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_dev.zip?download=true"
 
-elif [ "$DATASET" = "small" ]
-then
-  curl -L -o $DIR/train.zip  https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDsmall_train.zip?download=true
-  curl -L -o $DIR/dev.zip    https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDsmall_dev.zip?download=true
+elif [ "$DATASET" = "small" ]; then
+  curl -L -H "$HF_HEADER" -o $DIR/train.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDsmall_train.zip?download=true"
+  curl -L -H "$HF_HEADER" -o $DIR/dev.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDsmall_dev.zip?download=true"
 
-elif [ "$DATASET" = "large" ]
-then
-  curl -L -o $DIR/train.zip  https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_train.zip?download=true
-  curl -L -o $DIR/dev.zip    https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_dev.zip?download=true
+elif [ "$DATASET" = "large" ]; then
+  curl -L -H "$HF_HEADER" -o $DIR/train.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_train.zip?download=true"
+  curl -L -H "$HF_HEADER" -o $DIR/dev.zip "https://huggingface.co/datasets/yjw1029/MIND/resolve/main/MINDlarge_dev.zip?download=true"
 
 else
   echo "No dataset specified. Use demo|small|large."
@@ -31,4 +36,3 @@ fi
 # -j: extract flat (ignore paths in zip) since zips contain a nested folder
 unzip -j -o $DIR/train.zip -d $TRAIN_DIR
 unzip -j -o $DIR/dev.zip -d $DEV_DIR
-


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The HuggingFace download needs a HF token because terms and conditions needs to be accepted to download dataset. This was not the case before, but it's required now.