### PR TITLE
Bump httpclient5 5.6.4 (CRITICAL) + cryptography 50.0.0 / aiohttp 3.14.3 (4 Mend CVEs incl. 1 critical)

### DIFF
--- a/examples/reranker/pom.xml
+++ b/examples/reranker/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.6.2</version>
+            <version>5.6.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/visual-retrieval-colpali/src/legacy-requirements.txt
+++ b/visual-retrieval-colpali/src/legacy-requirements.txt
@@ -4,7 +4,7 @@ accelerate==1.13.0
     # via peft
 aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp==3.14.1
+aiohttp==3.14.3
     # via
     #   datasets
     #   fsspec
@@ -62,7 +62,7 @@ confection==1.3.3
     #   weasel
 contourpy==1.3.3
     # via matplotlib
-cryptography==48.0.1
+cryptography==50.0.0
     # via pyvespa
 cycler==0.12.1
     # via matplotlib


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging is the final step that closes out the linked Mend/Jira findings.

## Summary

Bumps `httpclient5` in `examples/reranker` to clear a Mend **CRITICAL**, and `cryptography` / `aiohttp` in `visual-retrieval-colpali/src/legacy-requirements.txt` to the first releases that patch three Mend HIGH findings. Three other CVEs Mend reports against this repo have **no released upstream fix** and are documented below rather than papered over. Tracked by VESPANG-3395.

## Changed Files

**`examples/reranker/pom.xml`**
- `org.apache.httpcomponents.client5:httpclient5`: `5.6.2` → `5.6.4`

**`visual-retrieval-colpali/src/legacy-requirements.txt`**
- `cryptography`: `48.0.1` → `50.0.0`
- `aiohttp`: `3.14.1` → `3.14.3`

## CVEs Addressed

Verified against the GitHub Advisory Database / OSV.dev:

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| httpclient5 | CVE-2026-71290 | **CRITICAL** | 5.6.4 |
| cryptography | CVE-2026-69247 | HIGH | 50.0.0 |
| cryptography | CVE-2026-69249 | HIGH | 49.0.0 (reached via 50.0.0) |
| aiohttp | CVE-2026-69244 | HIGH | 3.14.3 |

- **CVE-2026-71290** — `HostnameVerificationPolicy#BUILTIN` has no effect on the **async** HttpClient transport, so TLS hostname verification is silently disabled and a MITM can present a valid certificate for any other domain. Affects `httpclient5 >= 5.4`; Apache's guidance is "upgrade to at least version 5.6.4". The classic (sync) transport is not affected. GHSA-72q8-9rgw-5g6j.
- **CVE-2026-69247** — PKCS#7 `EnvelopedData` decryption exposes a Bleichenbacher oracle through distinguishable errors and timing. Introduced `44.0.0`, fixed `50.0.0`.
- **CVE-2026-69249** — duplicate self-signed intermediates cause exponential path-building. Fixed `49.0.0`.
- **CVE-2026-69244** — out-of-bounds heap read in the C HTTP response parser error path on a malformed chunked response. Fixed `3.14.3`.

`httpclient5` is a direct dependency in the reranker POM, so the bump is a straight version edit. `cryptography` and `aiohttp` are transitive and bounded only from below, so neither bump violates a declared range:

```
pyvespa 1.2.4         → cryptography>=48.0.1        (floor only)
fsspec / datasets     → aiohttp!=4.0.0a0,!=4.0.0a1  (excludes alphas only)
```

## ⚠️ Cannot fix in this PR

| Package | CVE | Severity | Reason |
|---|---|---|---|
| `sentence-transformers` @ 5.5.1 | CVE-2026-68770 | **CRITICAL** | **No fixed release exists — re-verified against the newest tag (5.7.0).** The flaw is the local-path short-circuit in `import_module_class` (`sentence_transformers/util/misc.py`), which satisfies the trust gate for any path that exists on disk, ignoring `trust_remote_code=False`. v5.7.0 refactored the guard to `trusted = trust_remote_code or is_local_dir` but **kept the short-circuit**, and still carries the upstream marker `TODO(v6.0): remove the 'or is_local_dir' short-circuit above` plus `TODO(v6.0): raise here instead of warning`. So bumping to 5.7.0 is a no-op for this CVE — only a v6.0 release clears it. Tracking upstream issue: UKPLab/sentence-transformers#3801. |
| `torchvision` @ 0.28.0 | CVE-2026-65918 | HIGH | **No fixed release exists.** The advisory states "through 0.28.0, fixed in commit 4e05dc2" — committed upstream but unreleased; `0.28.0` is still the newest version on PyPI. Source file `text-video-search/src/python/requirements.txt` lists `torchvision` unpinned, so it already floats to latest. Re-check on the next torchvision release. |
| `peft` @ 0.19.1 | CVE-2026-71281 | HIGH | **No fixed release exists.** The flaw is `torch.load` without `weights_only=True` on config-specified cache/covariance files in the LoRA-GA and CorDA initialization modules (`src/peft/tuners/lora/{corda,loraga}.py`). The latest release `0.20.0` is itself still flagged for this CVE on another Vespa repo (vespaembed, at exactly 0.20.0), so `0.19.1` → `0.20.0` would be a no-op. Source file cannot be recompiled anyway (see Implementation Notes). Re-check on the next peft release. |

## Implementation Notes

**Why the two Python pins were edited directly rather than recompiling.** `legacy-requirements.txt` is a `uv pip compile` output, so the normal move is to regenerate it. That is currently **impossible** — `visual-retrieval-colpali/pyproject.toml` no longer resolves:

```
$ uv pip compile pyproject.toml
  × No solution found when resolving dependencies:
  ╰─▶ ... sentence-transformers>=3.2.0,<=3.4.1 depends on transformers>=4.41.0,<5.0.0
      and vidore-benchmark>=5.0.0 depends on sentence-transformers>=3.0.1,<4.0.0,
      we can conclude that vidore-benchmark>=5.0.0 depends on transformers>=4.34.0,<5.0.0.
      And because visual-retrieval-colpali depends on
      vidore-benchmark[interpretability]>=5.0.0 and transformers==5.12.0, we
      can conclude that your requirements are unsatisfiable.
```

Editing the two pins in place matches how this file has actually been maintained — Renovate has landed five surgical single-pin security bumps to it (`pillow`, `httplib2`, `setuptools`, `torch`, `pyasn1`).

## ⚠️ Two pre-existing problems worth a follow-up (not introduced here)

Both were found while validating this change and need an owner decision; neither is caused by this PR:

1. **`pyproject.toml` is unsatisfiable** (output above). `transformers==5.12.0` conflicts with the `vidore-benchmark>=5.0.0,<5.1.0` → `sentence-transformers<4.0.0` → `transformers<5.0.0` chain. Until this is reconciled the documented `uv` install path in the README cannot work, and the file can never be regenerated.
2. **`legacy-requirements.txt` is itself unsatisfiable**, independently of this PR. Verified on unmodified `master`:
   ```
   × No solution found: colpali-engine>=0.3.17 depends on torch>=2.2.0,<2.12.0
     ... And because you require torch==2.13.0, your requirements are unsatisfiable.
   ```
   Renovate's `torch` → `2.13.0` security bump moved it past `colpali-engine`'s ceiling. So `pip install -r src/legacy-requirements.txt` (the path the README gives for the HuggingFace space) already fails on `master` today.

This PR deliberately does not attempt to fix either — both need a real dependency-set decision (pin `vidore-benchmark` lower, drop it, or move off `colpali-engine` 0.3.x), which is out of scope for a CVE bump.

## Pre-existing failures (not caused by this PR)

1. **`test / htmlproofer`** (workflow **Link checker**) fails on this PR **and on unmodified `master`** — the cause is a dead external link, unrelated to this change:
   ```
   External link https://www.shad4fasthtml.com/ failed (status code 404)
   ```
   Left alone deliberately: fixing an unrelated dead doc link does not belong in a CVE bump.

2. **`examples/reranker` does not compile locally with `-Werror`**, on this branch *and* on unmodified `master`:
   ```
   [WARNING] .../reranker/ResultReader.java:[60,79] fields() in com.fasterxml.jackson.databind.JsonNode has been deprecated
   [WARNING] .../reranker/ResultReader.java:[74,73] fields() in com.fasterxml.jackson.databind.JsonNode has been deprecated
   [ERROR] warnings found and -Werror specified
   ```
   `jackson-databind` is `provided`-scope here, so the version that triggers the deprecation comes from whichever Vespa `container` BOM Maven resolves locally. Reproduces identically on `master`, so it is not introduced by the `httpclient5` bump and is not fixed here.

## Verification

- GitHub Advisory Database / OSV.dev queried per package for each CVE; the fix versions above are `first_patched_version` / `fixed` events from those records, not Mend's claim
- `mvn dependency:tree` in `examples/reranker` confirms `org.apache.httpcomponents.client5:httpclient5:jar:5.6.4:compile`, with `httpcore5` and `httpcore5-h2` still at `5.4.3` — no downgrades in the graph
- `grep` of `sentence_transformers/util/misc.py` at tags `v5.5.1`, `v5.6.1` and `v5.7.0` confirms the CVE-2026-68770 short-circuit is still present in the newest release
- `pyvespa` / `fsspec` / `datasets` `requires_dist` inspected on PyPI to confirm no upper bound is crossed
- `uv pip install --dry-run -r src/legacy-requirements.txt` run in a `python:3.10-slim` container on **both** unmodified `master` and this branch — **identical** failure on each, confirming this change neither introduces nor worsens the pre-existing conflict
- No Python test suite was run: the app's dependency set cannot be installed at all (see above), so there is nothing runnable to exercise
- Re-run the Mend scan after merge to confirm the four listed CVEs clear
