### PR TITLE
Bump vespa-feed-client + pin BouncyCastle 1.85, opennlp 1.9.5 (19 CVEs incl. 2 critical)

### DIFF
--- a/examples/book-search/pom.xml
+++ b/examples/book-search/pom.xml
@@ -11,9 +11,32 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.11.4</junit.version>
-        <vespa_version>8.695.32</vespa_version>
+        <junit.version>5.14.4</junit.version>
+        <vespa_version>8.738.17</vespa_version>
     </properties>
+
+    <!-- vespa-feed-client 8.738.17 still pulls Bouncy Castle 1.84, affected by
+         CVE-2026-8763 (critical) + 16 HIGH CVEs fixed in BC 1.85; pinned here
+         until the platform ships 1.85+. Full rationale: PR / VESPANG-3395. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.85.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.85</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>1.85</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -36,13 +59,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.1</version>
+            <version>2.22.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.18</version>
+            <version>1.6.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/clients/client-java/app/build.gradle.kts
+++ b/examples/clients/client-java/app/build.gradle.kts
@@ -11,12 +11,20 @@ dependencies {
 
     implementation(libs.guava)
 
-    implementation("io.github.hakky54:ayza-for-pem:10.0.5")
-    implementation("org.eclipse.jetty:jetty-client:12.1.10")
-    implementation("org.eclipse.jetty.http2:jetty-http2-client-transport:12.1.10")
+    implementation("io.github.hakky54:ayza-for-pem:10.0.6")
+    implementation("org.eclipse.jetty:jetty-client:12.1.12")
+    implementation("org.eclipse.jetty.http2:jetty-http2-client-transport:12.1.12")
     implementation("org.slf4j:slf4j-simple:2.0.18")
     implementation("commons-cli:commons-cli:1.11.0")
-    implementation("com.yahoo.vespa:vespa-feed-client:8.677.31");
+    implementation("com.yahoo.vespa:vespa-feed-client:8.738.17");
+
+    constraints {
+        // vespa-feed-client 8.738.17 still pulls Bouncy Castle 1.84 (CVE-2026-8763
+        // critical + 16 HIGH, fixed in 1.85); constrained until the platform ships 1.85+.
+        implementation("org.bouncycastle:bcprov-jdk18on:1.85.2")
+        implementation("org.bouncycastle:bcpkix-jdk18on:1.85")
+        implementation("org.bouncycastle:bcutil-jdk18on:1.85")
+    }
 }
 
 java {

--- a/examples/clients/client-java/gradle/libs.versions.toml
+++ b/examples/clients/client-java/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/version_catalogs.html#sec::toml-dependencies-format
 
 [versions]
-guava = "33.6.0-jre"
+guava = "33.7.1-jre"
 junit = "4.13.2"
 
 [libraries]

--- a/examples/lucene-linguistics/going-crazy/pom.xml
+++ b/examples/lucene-linguistics/going-crazy/pom.xml
@@ -76,4 +76,17 @@
     </dependency>
   </dependencies>
 
+  <!-- lucene-analysis-opennlp pulls opennlp-tools 1.9.4. 1.9.5 (same line) fixes
+       CVE-2026-42027 (critical). CVE-2026-40682 + CVE-2026-42440 need opennlp 2.5.9,
+       a major jump lucene 9.x is not built against - see VESPANG-3395. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.opennlp</groupId>
+        <artifactId>opennlp-tools</artifactId>
+        <version>1.9.5</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/examples/operations/monitoring/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
+++ b/examples/operations/monitoring/album-recommendation-monitoring/album-recommendation-random-data/pom.xml
@@ -14,6 +14,29 @@
         <org.immutables.version>2.12.2</org.immutables.version>
     </properties>
 
+    <!-- vespa-feed-client 8.738.17 still pulls Bouncy Castle 1.84, affected by
+         CVE-2026-8763 (critical) + 16 HIGH CVEs fixed in BC 1.85; pinned here
+         until the platform ships 1.85+. Full rationale: PR / VESPANG-3395. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.85.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.85</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>1.85</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.immutables</groupId>
@@ -40,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.12.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
@@ -50,7 +73,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -75,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review all changes carefully before merging.**
>
> **Once approved, please merge it** — this is an automated dependency-update PR and merging is the final step that closes out the linked Mend/Jira findings.

## Summary
Fixes 19 Mend HIGH/CRITICAL CVEs (VESPANG-3395) across four example apps. The main cause: `vespa-feed-client` — including the latest 8.738.17 — still depends on Bouncy Castle 1.84, which carries 17 CVEs fixed in BC 1.85 (incl. critical CVE-2026-8763). Since no released platform version ships BC 1.85 yet, this PR pins BC explicitly in the three consumer manifests.

## Changed Files

**`examples/operations/monitoring/album-recommendation-monitoring/album-recommendation-random-data/pom.xml`**
- `dependencyManagement` pins: `bcprov-jdk18on 1.85.2`, `bcpkix-jdk18on 1.85`, `bcutil-jdk18on 1.85` (override vespa-feed-client's BC 1.84)
- plugins: maven-compiler 3.12.1 → 3.15.0, maven-assembly 3.6.0 → 3.8.0, maven-jar 3.3.0 → 3.5.1

**`examples/clients/client-java/app/build.gradle.kts`** + **`gradle/libs.versions.toml`**
- `vespa-feed-client`: 8.677.31 → 8.738.17 — brings jackson-core 2.21.1 → 2.22.1, which fixes CVE-2026-68494
- Gradle dependency constraints: BC 1.85.2 / 1.85 / 1.85 (same override as above)
- jetty-client + jetty-http2-client-transport 12.1.10 → 12.1.12, ayza-for-pem 10.0.5 → 10.0.6, guava 33.6.0-jre → 33.7.1-jre

**`examples/book-search/pom.xml`** (sibling fix — same vulnerable tree, not yet flagged by Mend)
- `vespa_version` 8.695.32 → 8.738.17, BC `dependencyManagement` pins as above
- junit 5.11.4 → 5.14.4, jackson-databind 2.22.1 → 2.22.2, logback-classic 1.5.18 → 1.6.3

**`examples/lucene-linguistics/going-crazy/pom.xml`**
- `dependencyManagement` pin: `opennlp-tools 1.9.5` (patch release in the same 1.9 line as the 1.9.4 pulled by lucene-analysis-opennlp) — fixes critical CVE-2026-42027

## CVEs Addressed

Verified against GitHub Advisory Database / OSV.dev:

| Package | CVE(s) | Severity | Fix version reached |
|---|---|---|---|
| bcprov-jdk18on | CVE-2026-8763 | critical | 1.85.2 |
| bcprov-jdk18on | CVE-2026-12185, CVE-2026-12803, CVE-2026-12816, CVE-2026-12860, CVE-2026-13506, CVE-2026-14682, CVE-2026-58059, CVE-2026-58060, CVE-2026-58061, CVE-2026-58062, CVE-2026-59650, CVE-2026-59651 | high | 1.85.2 |
| bcpkix-jdk18on | CVE-2026-12802, CVE-2026-59639, CVE-2026-59642 | high | 1.85 |
| bcutil-jdk18on | CVE-2026-59645 | high | 1.85 |
| jackson-core | CVE-2026-68494 | high | 2.22.1 (fixed ≥ 2.21.4 / 2.22.1; via vespa-feed-client 8.738.17) |
| opennlp-tools | CVE-2026-42027 | critical | 1.9.5 |

## ⚠️ Cannot fix in this PR

| Project | Package | CVE | Reason |
|---|---|---|---|
| lucene-linguistics/going-crazy | opennlp-tools @ 1.9.5 | CVE-2026-40682 (critical), CVE-2026-42440 (high) | Fixed only in opennlp 2.5.9 / 3.0.0-M3. lucene-analysis-opennlp 9.12.3 is built against opennlp 1.9.x; forcing a 1.9→2.5 major jump inside a deployed Vespa bundle risks runtime breakage. Needs a maintainer decision (carried over from earlier triage). |
| reverse-image-search/script | torchvision @ 0.28.0 | CVE-2026-65918 | Fix exists only as commit 4e05dc2; every released version through 0.28.0 (current latest on PyPI) is affected. Bump when the next torchvision release ships. |
| visual-retrieval-colpali/src | sentence-transformers @ 5.5.1 | CVE-2026-68770 | No fixed release upstream. |
| visual-retrieval-colpali/src | peft @ 0.19.1 | CVE-2026-71281 | No fixed release upstream; manifest pair also mutually unsatisfiable (earlier triage). |

## Implementation Notes
- BC 1.84 comes transitively from `vespa-feed-client` in all three consumer manifests; even the newest release (8.738.17, `bouncycastle.vespa.version=1.84`) is affected, hence explicit pins/constraints rather than a feed-client bump alone. The pins should be dropped once the platform moves to BC ≥ 1.85.
- bcpkix/bcutil have no 1.85.2 — 1.85 is their newest; bcprov's 1.85.2 is compatible.
- `book-search` junit went to 5.14.4 (latest 5.x) rather than junit 6: its tests are testcontainers/docker-gated and can't be exercised in this environment, so a major-version test-framework jump would be unverifiable.

## Verification
- `mvn package dependency:list` (album-recommendation-random-data, containerised): BUILD SUCCESS; resolves bcprov 1.85.2, bcpkix 1.85, bcutil 1.85, jackson-core 2.22.1
- `mvn package dependency:list` (going-crazy, containerised): BUILD SUCCESS; resolves opennlp-tools 1.9.5
- `./gradlew compileJava` + `app:dependencies` (client-java, containerised): BC 1.84 → 1.85/1.85.2 constraint applied, jackson-core 2.22.1, feed-client 8.738.17
- `mvn compile` (book-search, containerised): BUILD SUCCESS. **Pre-existing on master:** book-search `test` scope cannot resolve — `ai.vespa:vespa-testcontainers:1.0.0` is not on Maven Central (fails identically on unmodified master); not addressed here.
- Re-run the Mend scan after merge to confirm the listed CVEs clear.
- CI: all checks green except `test / htmlproofer`, which fails on an unrelated dead external link (`https://www.shad4fasthtml.com/`) and fails identically on master (pre-existing, not introduced here).
